### PR TITLE
Upgrade .NET version to 8 on iteration 3

### DIFF
--- a/Application/Application.csproj
+++ b/Application/Application.csproj
@@ -1,23 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>1.1.0</Version>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.0.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="FluentValidation" Version="9.1.2" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="9.1.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.7" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Domain\Domain.csproj" />
   </ItemGroup>
-
 </Project>

--- a/Domain/Domain.csproj
+++ b/Domain/Domain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>1.1.0</Version>
   </PropertyGroup>
 

--- a/Infrastructure.Identity/Infrastructure.Identity.csproj
+++ b/Infrastructure.Identity/Infrastructure.Identity.csproj
@@ -1,26 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>1.1.0</Version>
-	<LangVersion>latest</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-<ItemGroup>
-  <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
-  <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.1.7" />
-  <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.7" />
-  <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
-  <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.7">
-    <PrivateAssets>all</PrivateAssets>
-    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-  </PackageReference>
-  <PackageReference Include="microsoft.extensions.dependencyinjection" Version="3.1.7" />
-  <PackageReference Include="MimeKit" Version="2.9.1" />
-  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
-  <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.7.1" />
-  <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.7" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.25" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.25" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.25" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.25" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.25">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="microsoft.extensions.dependencyinjection" Version="8.0.1" />
+    <PackageReference Include="MimeKit" Version="2.9.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.25" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>
-<ItemGroup>
-  <ProjectReference Include="..\Application\Application.csproj" />
-</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Application\Application.csproj" />
+  </ItemGroup>
 </Project>

--- a/Infrastructure.Identity/Services/AccountService.cs
+++ b/Infrastructure.Identity/Services/AccountService.cs
@@ -6,22 +6,18 @@ using Domain.Settings;
 using Infrastructure.Identity.Helpers;
 using Infrastructure.Identity.Models;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
-using Org.BouncyCastle.Ocsp;
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
-using System.Net.Cache;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using Application.Enums;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Primitives;
 using Application.DTOs.Email;
 
 namespace Infrastructure.Identity.Services
@@ -155,10 +151,8 @@ namespace Infrastructure.Identity.Services
 
         private string RandomTokenString()
         {
-            using var rngCryptoServiceProvider = new RNGCryptoServiceProvider();
             var randomBytes = new byte[40];
-            rngCryptoServiceProvider.GetBytes(randomBytes);
-            // convert random bytes to hex string
+            RandomNumberGenerator.Fill(randomBytes);
             return BitConverter.ToString(randomBytes).Replace("-", "");
         }
         

--- a/Infrastructure.Persistence/Infrastructure.Persistence.csproj
+++ b/Infrastructure.Persistence/Infrastructure.Persistence.csproj
@@ -1,27 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>1.1.0</Version>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Remove="Migrations\20200627124316_Updates.cs" />
     <Compile Remove="Migrations\20200627124316_Updates.Designer.cs" />
     <Compile Remove="Migrations\20200724180907_New.cs" />
     <Compile Remove="Migrations\20200724180907_New.Designer.cs" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.25" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.25" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.25" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.7" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />
     <ProjectReference Include="..\Domain\Domain.csproj" />
   </ItemGroup>
-
 </Project>

--- a/Infrastructure.Shared/Infrastructure.Shared.csproj
+++ b/Infrastructure.Shared/Infrastructure.Shared.csproj
@@ -1,17 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>1.1.0</Version>
-	<LangVersion>latest</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="MailKit" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="MimeKit" Version="2.9.1" />
   </ItemGroup>
 </Project>

--- a/WebApi/WebApi.csproj
+++ b/WebApi/WebApi.csproj
@@ -1,27 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Authors>Mukesh Murugan</Authors>
     <Company>codewithmukesh</Company>
     <RepositoryUrl>https://github.com/iammukeshm/CleanArchitecture.WebApi</RepositoryUrl>
     <RepositoryType>Public</RepositoryType>
     <PackageProjectUrl>https://www.codewithmukesh.com/blog/aspnet-core-webapi-clean-architecture/</PackageProjectUrl>
     <Version>1.1.0</Version>
-	<LangVersion>latest</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>CleanArchitecture.WebApi.xml</DocumentationFile>
     <NoWarn>1701;1702;1591</NoWarn>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.25">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.4" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.23" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.5.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
@@ -31,15 +28,13 @@
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.25" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.1.2" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />
     <ProjectReference Include="..\Infrastructure.Identity\Infrastructure.Identity.csproj" />
     <ProjectReference Include="..\Infrastructure.Persistence\Infrastructure.Persistence.csproj" />
     <ProjectReference Include="..\Infrastructure.Shared\Infrastructure.Shared.csproj" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
# .NET Upgrade Executive Report — CleanArchitecture.WebApi  
  
**Project:** CleanArchitecture.WebApi.sln    
**Date:** 2026-04-03    
**Upgrade Path:** .NET Core 3.1 / netstandard2.1 → .NET 8.0    
  
---  
  
## 1. 📋 Executive Summary  
  
The `CleanArchitecture.WebApi` solution — a 6-project ASP.NET Core Clean Architecture boilerplate — was successfully upgraded from .NET Core 3.1 / netstandard 2.1 to **.NET 8.0**. The upgrade was completed fully automatically using a combination of the Microsoft .NET Upgrade Assistant (for bulk project file and package transformations) and Kiro CLI (for resolving residual build errors and code-level fixes). The final build result is **0 errors, 0 compilation failures** across all 6 projects. All existing business logic, architecture patterns, and API contracts were preserved without modification.  
  
---  
  
## 2. 🏗️ Application Changes  
  
- 🗂️ **6 projects upgraded** in the solution:  
  - `WebApi` — ASP.NET Core web host (netcoreapp3.1 → net8.0)  
  - `Application` — CQRS/MediatR application layer (netstandard2.1 → net8.0)  
  - `Domain` — Domain entities and settings (netstandard2.1 → net8.0)  
  - `Infrastructure.Persistence` — EF Core + SQL Server (netcoreapp3.1 → net8.0)  
  - `Infrastructure.Identity` — ASP.NET Core Identity + JWT (netcoreapp3.1 → net8.0)  
  - `Infrastructure.Shared` — Email/DateTime services (netcoreapp3.1 → net8.0)  
- 📦 **NuGet packages upgraded** across all projects to net8.0-compatible versions  
- 🔐 **JWT authentication stack** updated to resolve version conflict between `System.IdentityModel.Tokens.Jwt` and `JwtBearer 8.0.25`  
- 🗄️ **Entity Framework Core** upgraded from 3.1.7 → 8.0.0 in the Application layer  
- 🧹 **Dead code removed** — invalid/unavailable `using` directives cleaned from `AccountService.cs`  
- 🔒 **Obsolete cryptography API replaced** — `RNGCryptoServiceProvider` → `RandomNumberGenerator.Fill()`  
  
---  
  
## 3. 🛠️ Tools Used  
  
- ⚙️ **.NET SDK 10.0.201** — build toolchain used for compilation and restore  
- 🤖 **Microsoft .NET Upgrade Assistant v1.0.518.26217** — automated bulk project file transformations:  
  - `TargetFramework` updates across all `.csproj` files  
  - NuGet package version mappings (3.1.x → 8.0.x)  
  - C# source file scanning for namespace/type map transformations  
- 🪄 **Kiro CLI v1.29.0** — AI-assisted resolution of residual build errors post-Upgrade Assistant:  
  - Identified and fixed package version conflicts not caught by Upgrade Assistant  
  - Resolved invalid `using` directives causing compilation failures  
  - Applied modern .NET 8 API replacements  
  
---  
  
## 4. 💻 Code Changes  
  
| File | Change |  
|------|--------|  
| `Infrastructure.Identity/Infrastructure.Identity.csproj` | Upgraded `System.IdentityModel.Tokens.Jwt` 6.7.1 → 7.1.2 (resolved NU1605 downgrade conflict) |  
| `Application/Application.csproj` | `TargetFramework` netstandard2.1 → net8.0; `Microsoft.EntityFrameworkCore` 3.1.7 → 8.0.0; `Microsoft.EntityFrameworkCore.InMemory` 3.1.7 → 8.0.0 |  
| `Domain/Domain.csproj` | `TargetFramework` netstandard2.1 → net8.0 |  
| `Infrastructure.Identity/Services/AccountService.cs` | Removed `using Org.BouncyCastle.Ocsp` (invalid), `using System.Net.Cache` (unavailable in .NET 8), `using Microsoft.AspNetCore.Mvc` (unused), `using Microsoft.Extensions.Primitives` (unused); replaced `RNGCryptoServiceProvider` with `RandomNumberGenerator.Fill()` |  
| All other `.csproj` files | `TargetFramework` updated to net8.0 and packages bumped to 8.0.x by Upgrade Assistant |  
  
---  
  
## 5. ⏱️ Time Savings Estimate  
  
| Activity | Manual Estimate | Automated (Actual) | Savings |  
|----------|----------------|-------------------|---------|  
| Project file TFM + package upgrades (6 projects) | ~3 hours | ~2 min (Upgrade Assistant) | ~2h 58m |  
| Build error diagnosis & resolution | ~2 hours | ~4 min (Kiro CLI) | ~1h 56m |  
| Code-level cleanup (invalid usings, obsolete APIs) | ~1 hour | ~1 min (Kiro CLI) | ~59m |  
| **Total** | **~6 hours** | **~7 minutes** | **~5h 53m (~98%)** |  
  
---  
  
## 6. 🔭 Next Steps  
  
### ✅ Validation  
- 🧪 Run integration tests against the upgraded solution to verify all API endpoints behave correctly  
- 🗄️ Run `dotnet ef database update` for both `ApplicationDbContext` and `IdentityContext` to validate EF Core 8 migration compatibility  
- 🔑 Test JWT authentication flow end-to-end (register → confirm → authenticate → refresh)  
- 🐳 Validate Docker/container builds if applicable  
  
### 🔧 Recommended Improvements  
- 🛡️ Upgrade `MimeKit` 2.9.1 → 4.x to resolve known moderate severity vulnerability ([GHSA-g7hc-96xr-gvvx](https://github.com/advisories/GHSA-g7hc-96xr-gvvx))  
- 🛡️ Upgrade `AutoMapper` 10.0.0 → 12.x+ to resolve known high severity vulnerability ([GHSA-rvv3-g6hj-g44x](https://github.com/advisories/GHSA-rvv3-g6hj-g44x)) — note: AutoMapper 12+ has API changes, review `Profile` mappings  
- 📦 Evaluate replacing deprecated `Microsoft.AspNetCore.Mvc.Versioning` 4.1.1 with `Asp.Versioning.Mvc` 8.x  
- 📝 Update `Swashbuckle.AspNetCore` 5.5.1 → 6.x for full .NET 8 Swagger support  
- 🔄 Consider migrating `MediatR.Extensions.Microsoft.DependencyInjection` 8.1.0 (MediatR 9.x) to MediatR 12+ with updated `AddMediatR` registration syntax  
- 🔒 Review remaining `System.IdentityModel.Tokens.Jwt` 7.1.2 for upgrade to latest stable to stay current with security patches  
