### PR TITLE
Upgrade .NET version to 8 on iteration 8

### DIFF
--- a/Application/Application.csproj
+++ b/Application/Application.csproj
@@ -1,18 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>1.1.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="10.0.0" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="FluentValidation" Version="9.1.2" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="9.1.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.7" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="System.Text.Json" Version="8.0.6" />
+    <PackageReference Include="AutoMapper" Version="14.0.0" />
+    <PackageReference Include="FluentValidation" Version="11.3.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.3.0" />
+    <PackageReference Include="MediatR" Version="12.4.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Domain\Domain.csproj" />

--- a/Application/Behaviours/ValidationBehaviour.cs
+++ b/Application/Behaviours/ValidationBehaviour.cs
@@ -17,7 +17,7 @@ namespace Application.Behaviours
             _validators = validators;
         }
 
-        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
         {
             if (_validators.Any())
             {

--- a/Application/ServiceExtensions.cs
+++ b/Application/ServiceExtensions.cs
@@ -17,7 +17,7 @@ namespace Application
         {
             services.AddAutoMapper(Assembly.GetExecutingAssembly());
             services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
-            services.AddMediatR(Assembly.GetExecutingAssembly());
+            services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()));
             services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
 
         }

--- a/Domain/Domain.csproj
+++ b/Domain/Domain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>1.1.0</Version>
   </PropertyGroup>
 

--- a/Infrastructure.Identity/Infrastructure.Identity.csproj
+++ b/Infrastructure.Identity/Infrastructure.Identity.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="microsoft.extensions.dependencyinjection" Version="8.0.1" />
-    <PackageReference Include="MimeKit" Version="2.9.1" />
+    <PackageReference Include="MimeKit" Version="4.16.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.26" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />

--- a/Infrastructure.Identity/ServiceExtensions.cs
+++ b/Infrastructure.Identity/ServiceExtensions.cs
@@ -13,10 +13,10 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
-using Newtonsoft.Json;
 using System;
 using System.Reflection.Metadata.Ecma335;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace Infrastructure.Identity
@@ -76,14 +76,14 @@ namespace Infrastructure.Identity
                             context.HandleResponse();
                             context.Response.StatusCode = 401;
                             context.Response.ContentType = "application/json";
-                            var result = JsonConvert.SerializeObject(new Response<string>("You are not Authorized"));
+                            var result = JsonSerializer.Serialize(new Response<string>("You are not Authorized"));
                             return context.Response.WriteAsync(result);
                         },
                         OnForbidden = context =>
                         {
                             context.Response.StatusCode = 403;
                             context.Response.ContentType = "application/json";
-                            var result = JsonConvert.SerializeObject(new Response<string>("You are not authorized to access this resource"));
+                            var result = JsonSerializer.Serialize(new Response<string>("You are not authorized to access this resource"));
                             return context.Response.WriteAsync(result);
                         },
                     };

--- a/Infrastructure.Shared/Infrastructure.Shared.csproj
+++ b/Infrastructure.Shared/Infrastructure.Shared.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />
-    <PackageReference Include="MailKit" Version="2.8.0" />
+    <PackageReference Include="MailKit" Version="4.16.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageReference Include="MimeKit" Version="2.9.1" />
+    <PackageReference Include="MimeKit" Version="4.16.0" />
   </ItemGroup>
 </Project>

--- a/WebApi/WebApi.csproj
+++ b/WebApi/WebApi.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="9.1.2" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />


### PR DESCRIPTION
# .NET Upgrade Executive Report — CleanArchitecture.WebApi  
**Date:** 2026-04-23 | **Iteration:** 8 | **Duration:** ~7 minutes  
  
---  
  
## 📋 Executive Summary  
  
The `CleanArchitecture.WebApi` solution was successfully upgraded from a mixed `netstandard2.1` / `net8.0` state to a fully unified `net8.0` target across all 6 projects. The upgrade assistant handled initial project file scaffolding for the `Domain` and `Application` projects, while Kiro CLI resolved all remaining compilation errors, replaced deprecated package dependencies, and updated breaking API changes introduced by major library version jumps (MediatR 8→12, AutoMapper 10→14, FluentValidation 9→11, MailKit/MimeKit 2→4). The final build exits with **0 errors** and all 6 projects compile cleanly against .NET 8.  
  
---  
  
## 🏗️ Application Changes  
  
- 🎯 **Domain** — target upgraded from `netstandard2.1` → `net8.0`  
- 🎯 **Application** — target upgraded from `netstandard2.1` → `net8.0`  
- ✅ **WebApi, Infrastructure.Identity, Infrastructure.Persistence, Infrastructure.Shared** — already targeting `net8.0`; packages updated  
- 📦 All 6 projects now share a single unified `net8.0` target framework  
  
---  
  
## 🛠️ Tools Used  
  
- 🔧 **.NET SDK `10.0.203`** — build, restore, and compilation verification via `dotnet build`  
- 🤖 **Microsoft .NET Upgrade Assistant `1.0.518.26217`** — automated project file scaffolding, `TargetFramework` transformer, and C# code namespace scanning across `Domain` and `Application` projects  
- 🪄 **Kiro CLI `2.0.1`** — AI-driven automated fix loop: identified vulnerable/outdated packages, resolved breaking API changes, fixed compilation errors, and verified zero-error build; model used: **Claude Sonnet 4.5**  
  
---  
  
## 💻 Code Changes  
  
### Project Files (`.csproj`)  
- 📝 `Domain/Domain.csproj` — `netstandard2.1` → `net8.0`  
- 📝 `Application/Application.csproj` — `netstandard2.1` → `net8.0`; full package refresh (see table below)  
- 📝 `WebApi/WebApi.csproj` — `FluentValidation.AspNetCore` 9.1.2 → 11.3.1  
- 📝 `Infrastructure.Shared/Infrastructure.Shared.csproj` — `MailKit` 2.8.0 → 4.16.0, `MimeKit` 2.9.1 → 4.16.0  
- 📝 `Infrastructure.Identity/Infrastructure.Identity.csproj` — `MimeKit` 2.9.1 → 4.16.0  
  
### Package Upgrades  
  
| Project | Package | Before | After |  
|---|---|---|---|  
| Application | AutoMapper | 10.0.0 | 14.0.0 |  
| Application | AutoMapper.Extensions.Microsoft.DI | 8.0.1 | ❌ removed (built into AutoMapper 13+) |  
| Application | MediatR.Extensions.Microsoft.DI | 8.1.0 | ❌ removed (built into MediatR 12+) |  
| Application | MediatR | — | 12.4.1 ✅ |  
| Application | FluentValidation | 9.1.2 | 11.3.0 |  
| Application | FluentValidation.DependencyInjectionExtensions | 9.1.2 | 11.3.0 |  
| Application | Microsoft.EntityFrameworkCore | 3.1.7 | 8.0.11 |  
| Application | Microsoft.EntityFrameworkCore.InMemory | 3.1.7 | 8.0.11 |  
| WebApi | FluentValidation.AspNetCore | 9.1.2 | 11.3.1 |  
| Infrastructure.Shared | MailKit | 2.8.0 | 4.16.0 |  
| Infrastructure.Shared | MimeKit | 2.9.1 | 4.16.0 |  
| Infrastructure.Identity | MimeKit | 2.9.1 | 4.16.0 |  
  
### Source Code (`.cs`)  
- 🔄 `Application/ServiceExtensions.cs` — updated `AddMediatR` to MediatR 12 API: `cfg.RegisterServicesFromAssembly(...)`  
- 🔄 `Application/Behaviours/ValidationBehaviour.cs` — fixed `IPipelineBehavior.Handle` signature (MediatR 12 swapped `next` and `cancellationToken` parameter order)  
- 🔄 `Infrastructure.Identity/ServiceExtensions.cs` — replaced `Newtonsoft.Json` / `JsonConvert.SerializeObject` with built-in `System.Text.Json` / `JsonSerializer.Serialize`  
  
---  
  
## ⏱️ Time Savings Estimate  
  
| Task | Manual Estimate | Automated |  
|---|---|---|  
| Project file analysis & TFM upgrades | 1–2 hrs | ~1 min |  
| Package compatibility research (12 packages) | 2–3 hrs | ~2 min |  
| Breaking API fixes (MediatR, AutoMapper, FV) | 2–4 hrs | ~3 min |  
| Newtonsoft → System.Text.Json migration | 30–60 min | <1 min |  
| Iterative build/fix cycles | 1–2 hrs | ~1 min |  
| **Total** | **~7–12 hrs** | **~7 min** |  
  
- 💰 **Estimated savings: 7–12 engineer-hours** (~95% reduction in upgrade time)  
- 🔁 **Build iterations required:** 3 (initial → fix Newtonsoft error → fix AutoMapper version)  
  
---  
  
## 🚀 Next Steps  
  
### ✅ Validation  
- 🧪 Run integration tests against the upgraded solution to verify runtime behaviour  
- 🔍 Validate JWT authentication flows end-to-end (Identity service was modified)  
- 🗄️ Run `dotnet ef database update` for both `ApplicationDbContext` and `IdentityContext` to confirm EF Core 8 migration compatibility  
- 🌐 Smoke-test Swagger UI (`/swagger`) and health endpoint (`/health`)  
  
### 🔧 Improvement Recommendations  
- ⚠️ **AutoMapper advisory** — NuGet flags `GHSA-rvv3-g6hj-g44x` (ReDoS) across all AutoMapper versions; monitor the advisory for an official fix or evaluate replacing AutoMapper with `Mapperly` (source-generator based, no runtime reflection)  
- 📦 **Swashbuckle** — currently on 5.5.1; latest is 10.1.7 — upgrade recommended for .NET 8 OpenAPI improvements and security fixes  
- 📦 **Serilog.AspNetCore** — currently on 3.4.0; latest is 8.x — upgrade for .NET 8 structured logging improvements  
- 🔒 **`Microsoft.AspNetCore.Mvc.Versioning`** — package is deprecated; migrate to `Asp.Versioning.Mvc` (the official successor)  
- 🐳 Consider adding a `Dockerfile` targeting the `net8.0` runtime image (`mcr.microsoft.com/dotnet/aspnet:8.0`) for containerised deployments  
- 📋 Add a CI pipeline step to run `dotnet list package --vulnerable` on every PR to catch future security advisories early  
