### PR TITLE
Upgrade .NET version to 8 on iteration 2

### DIFF
--- a/Application/Application.csproj
+++ b/Application/Application.csproj
@@ -1,23 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>1.1.0</Version>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.0.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="FluentValidation" Version="9.1.2" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="9.1.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.26" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.7" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.26" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Domain\Domain.csproj" />
   </ItemGroup>
-
 </Project>

--- a/Domain/Domain.csproj
+++ b/Domain/Domain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>1.1.0</Version>
   </PropertyGroup>
 

--- a/Infrastructure.Identity/Infrastructure.Identity.csproj
+++ b/Infrastructure.Identity/Infrastructure.Identity.csproj
@@ -1,26 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>1.1.0</Version>
-	<LangVersion>latest</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-<ItemGroup>
-  <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
-  <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.1.7" />
-  <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.7" />
-  <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
-  <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.7">
-    <PrivateAssets>all</PrivateAssets>
-    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-  </PackageReference>
-  <PackageReference Include="microsoft.extensions.dependencyinjection" Version="3.1.7" />
-  <PackageReference Include="MimeKit" Version="2.9.1" />
-  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
-  <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.7.1" />
-  <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.7" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.26" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.26" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.26" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.26" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.26">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="microsoft.extensions.dependencyinjection" Version="8.0.1" />
+    <PackageReference Include="MimeKit" Version="2.9.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.26" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>
-<ItemGroup>
-  <ProjectReference Include="..\Application\Application.csproj" />
-</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Application\Application.csproj" />
+  </ItemGroup>
 </Project>

--- a/Infrastructure.Identity/Services/AccountService.cs
+++ b/Infrastructure.Identity/Services/AccountService.cs
@@ -6,22 +6,18 @@ using Domain.Settings;
 using Infrastructure.Identity.Helpers;
 using Infrastructure.Identity.Models;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
-using Org.BouncyCastle.Ocsp;
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
-using System.Net.Cache;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using Application.Enums;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Primitives;
 using Application.DTOs.Email;
 
 namespace Infrastructure.Identity.Services
@@ -155,10 +151,7 @@ namespace Infrastructure.Identity.Services
 
         private string RandomTokenString()
         {
-            using var rngCryptoServiceProvider = new RNGCryptoServiceProvider();
-            var randomBytes = new byte[40];
-            rngCryptoServiceProvider.GetBytes(randomBytes);
-            // convert random bytes to hex string
+            var randomBytes = RandomNumberGenerator.GetBytes(40);
             return BitConverter.ToString(randomBytes).Replace("-", "");
         }
         

--- a/Infrastructure.Persistence/Infrastructure.Persistence.csproj
+++ b/Infrastructure.Persistence/Infrastructure.Persistence.csproj
@@ -1,27 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>1.1.0</Version>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Remove="Migrations\20200627124316_Updates.cs" />
     <Compile Remove="Migrations\20200627124316_Updates.Designer.cs" />
     <Compile Remove="Migrations\20200724180907_New.cs" />
     <Compile Remove="Migrations\20200724180907_New.Designer.cs" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.26" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.26" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.26" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.7" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />
     <ProjectReference Include="..\Domain\Domain.csproj" />
   </ItemGroup>
-
 </Project>

--- a/Infrastructure.Shared/Infrastructure.Shared.csproj
+++ b/Infrastructure.Shared/Infrastructure.Shared.csproj
@@ -1,17 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>1.1.0</Version>
-	<LangVersion>latest</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="MailKit" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="MimeKit" Version="2.9.1" />
   </ItemGroup>
 </Project>

--- a/WebApi/WebApi.csproj
+++ b/WebApi/WebApi.csproj
@@ -1,27 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Authors>Mukesh Murugan</Authors>
     <Company>codewithmukesh</Company>
     <RepositoryUrl>https://github.com/iammukeshm/CleanArchitecture.WebApi</RepositoryUrl>
     <RepositoryType>Public</RepositoryType>
     <PackageProjectUrl>https://www.codewithmukesh.com/blog/aspnet-core-webapi-clean-architecture/</PackageProjectUrl>
     <Version>1.1.0</Version>
-	<LangVersion>latest</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>CleanArchitecture.WebApi.xml</DocumentationFile>
     <NoWarn>1701;1702;1591</NoWarn>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.26">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.4" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.23" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.5.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
@@ -31,15 +28,13 @@
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.1.2" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />
     <ProjectReference Include="..\Infrastructure.Identity\Infrastructure.Identity.csproj" />
     <ProjectReference Include="..\Infrastructure.Persistence\Infrastructure.Persistence.csproj" />
     <ProjectReference Include="..\Infrastructure.Shared\Infrastructure.Shared.csproj" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
# .NET Upgrade Executive Report — CleanArchitecture.WebApi  
  
**Project:** CleanArchitecture.WebApi.sln    
**Upgrade:** netcoreapp3.1 / netstandard2.1 → net8.0    
**Date:** 2026-05-11    
**Outcome:** ✅ Build succeeded — 0 errors  
  
---  
  
## 1. Executive Summary  
  
The CleanArchitecture.WebApi solution (6 projects, Clean Architecture / Onion pattern with CQRS, EF Core, ASP.NET Core Identity, and JWT authentication) was successfully upgraded from .NET Core 3.1 / .NET Standard 2.1 to .NET 8.0. The upgrade was executed in two automated phases: Microsoft Upgrade Assistant performed the bulk project-file and NuGet package transformations, and Kiro CLI resolved the remaining compilation blockers — a JWT package version conflict, stale target frameworks on library projects, and deprecated cryptography API usage. The final `dotnet build` completed with **0 errors** across all 6 projects.  
  
---  
  
## 2. Application Changes  
  
- 🏗️ **Solution:** `CleanArchitecture.WebApi.sln` — 6 projects migrated  
- 📦 **Projects upgraded:**  
  - `WebApi` — netcoreapp3.1 → net8.0  
  - `Application` — netstandard2.1 → net8.0  
  - `Domain` — netstandard2.1 → net8.0  
  - `Infrastructure.Persistence` — netcoreapp3.1 → net8.0  
  - `Infrastructure.Identity` — netcoreapp3.1 → net8.0  
  - `Infrastructure.Shared` — netcoreapp3.1 → net8.0  
- 🔑 **Architecture preserved:** Clean Architecture / Onion pattern, CQRS with MediatR, EF Core repositories, ASP.NET Core Identity + JWT, Serilog, Swagger  
- ⚠️ **Remaining warnings (non-blocking):** Known vulnerabilities in `AutoMapper 10.0.0`, `MailKit 2.8.0`, `MimeKit 2.9.1` — functional but flagged for future patching  
  
---  
  
## 3. Tools Used  
  
| Tool | Version | Role |  
|------|---------|------|  
| 🔧 **.NET SDK** | 10.0.203 | Build, restore, compile verification |  
| 🤖 **Microsoft Upgrade Assistant** | 1.0.518 | Automated project file & NuGet package transformations |  
| 🪄 **Kiro CLI** | 2.0.1 (claude-sonnet-4-5) | Compilation error diagnosis and targeted code fixes |  
  
---  
  
## 4. Code Changes  
  
### Automated by Upgrade Assistant  
- ✅ `TargetFramework` updated from `netcoreapp3.1` → `net8.0` in WebApi, Infrastructure.Persistence, Infrastructure.Identity, Infrastructure.Shared  
- ✅ NuGet packages upgraded to net8.0-compatible versions:  
  - `Microsoft.AspNetCore.Authentication.JwtBearer` 3.1.18 → 8.0.26  
  - `Microsoft.AspNetCore.Identity.EntityFrameworkCore` 3.1.7 → 8.0.26  
  - `Microsoft.EntityFrameworkCore.SqlServer` 3.1.7 → 8.0.26  
  - `Microsoft.EntityFrameworkCore.InMemory` 3.1.7 → 8.0.26  
  - `Microsoft.EntityFrameworkCore.Tools` 3.1.7 → 8.0.26  
  - `Microsoft.AspNetCore.Mvc.NewtonsoftJson` 3.1.7 → 8.0.26  
  - `Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore` 3.1.7 → 8.0.26  
  - `Microsoft.Extensions.Options.ConfigurationExtensions` 3.1.7 → 8.0.0  
  - `Microsoft.VisualStudio.Web.CodeGeneration.Design` 3.1.4 → 8.0.23  
  - `Newtonsoft.Json` 12.0.3 → 13.0.4  
  - `System.Text.Json` 4.7.2 → 8.0.6  
  
### Fixed by Kiro CLI  
- ✅ `Infrastructure.Identity/Infrastructure.Identity.csproj` — upgraded `System.IdentityModel.Tokens.Jwt` 6.7.1 → 7.1.2 to resolve NU1605 package downgrade conflict with JwtBearer 8.0.26  
- ✅ `Application/Application.csproj` — changed target from `netstandard2.1` → `net8.0`; upgraded `Microsoft.EntityFrameworkCore` and `Microsoft.EntityFrameworkCore.InMemory` 3.1.7 → 8.0.26  
- ✅ `Domain/Domain.csproj` — changed target from `netstandard2.1` → `net8.0`  
- ✅ `Infrastructure.Identity/Services/AccountService.cs` — removed 4 invalid/unavailable `using` directives (`Org.BouncyCastle.Ocsp`, `System.Net.Cache`, `Microsoft.AspNetCore.Mvc`, `Microsoft.Extensions.Primitives`); replaced deprecated `RNGCryptoServiceProvider` with `RandomNumberGenerator.GetBytes()`  
  
---  
  
## 5. Time Savings Estimate  
  
| Activity | Manual Estimate | Automated | Savings |  
|----------|----------------|-----------|---------|  
| 🔍 Project file analysis & TFM updates (6 projects) | 1–2 hrs | ~1 min | ~1.5 hrs |  
| 📦 NuGet package research & version resolution (15+ packages) | 2–4 hrs | ~2 min | ~3 hrs |  
| 🐛 Compilation error diagnosis & fix (JWT conflict, deprecated APIs) | 1–2 hrs | ~4 min | ~1.5 hrs |  
| 📝 Code scanning for removed/changed APIs | 1–2 hrs | ~1 min | ~1.5 hrs |  
| **Total** | **5–10 hrs** | **~8 min** | **~7.5 hrs (85–90%)** |  
  
---  
  
## 6. Next Steps  
  
### Validation  
- 🧪 **Run integration tests** — verify JWT authentication, EF Core migrations, and Identity seeding work end-to-end against a real database  
- 🗄️ **Re-run EF Core migrations** — existing migrations were generated under EF Core 3.1; regenerate or verify compatibility with EF Core 8 (`dotnet ef migrations add` / `dotnet ef database update`)  
- 🔐 **Test auth flows** — authenticate, register, confirm email, refresh token, and role-based access endpoints  
- 🩺 **Verify health check endpoint** (`/health`) and Swagger UI (`/swagger`) load correctly  
  
### Recommended Improvements  
- 🔒 **Patch vulnerable packages:**  
  - `AutoMapper 10.0.0` → upgrade to 12.x+ (high severity CVE)  
  - `MailKit 2.8.0` → upgrade to 4.x+ (moderate severity CVE)  
  - `MimeKit 2.9.1` → upgrade to 4.x+ (moderate severity CVE)  
- 📌 **Pin `Serilog.Sinks.MSSqlServer`** to a current version (5.5.1 is outdated; current is 8.x)  
- 🚀 **Consider minimal hosting model** — migrate `Startup.cs` + `Program.cs` to the .NET 6+ minimal hosting pattern (`WebApplication.CreateBuilder`)  
- 🐳 **Containerize** — add a `Dockerfile` targeting the `mcr.microsoft.com/dotnet/aspnet:8.0` base image for Linux deployment  
- ✅ **Add unit/integration tests** — the project currently has no test projects; add xUnit + WebApplicationFactory coverage for controllers and handlers  
