### PR TITLE
Upgrade .NET version to 10 on iteration 4

### DIFF
--- a/Application/Application.csproj
+++ b/Application/Application.csproj
@@ -1,18 +1,16 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.1.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="10.0.0" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="FluentValidation" Version="9.1.2" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="9.1.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.26" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.26" />
+    <PackageReference Include="AutoMapper" Version="16.1.1" />
+    <PackageReference Include="FluentValidation" Version="11.4.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.4.0" />
+    <PackageReference Include="MediatR" Version="14.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Domain\Domain.csproj" />

--- a/Application/Behaviours/ValidationBehaviour.cs
+++ b/Application/Behaviours/ValidationBehaviour.cs
@@ -1,4 +1,4 @@
-﻿using FluentValidation;
+using FluentValidation;
 using MediatR;
 using System.Collections.Generic;
 using System.Linq;
@@ -17,7 +17,7 @@ namespace Application.Behaviours
             _validators = validators;
         }
 
-        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
         {
             if (_validators.Any())
             {

--- a/Application/ServiceExtensions.cs
+++ b/Application/ServiceExtensions.cs
@@ -1,13 +1,9 @@
-﻿using Application.Behaviours;
-using Application.Features.Products.Commands.CreateProduct;
+using Application.Behaviours;
 using AutoMapper;
 using FluentValidation;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
-using System;
-using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 
 namespace Application
 {
@@ -15,11 +11,10 @@ namespace Application
     {
         public static void AddApplicationLayer(this IServiceCollection services)
         {
-            services.AddAutoMapper(Assembly.GetExecutingAssembly());
+            services.AddAutoMapper(cfg => cfg.AddMaps(Assembly.GetExecutingAssembly()));
             services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
-            services.AddMediatR(Assembly.GetExecutingAssembly());
+            services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()));
             services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
-
         }
     }
 }

--- a/Domain/Domain.csproj
+++ b/Domain/Domain.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.1.0</Version>
   </PropertyGroup>
-
 </Project>

--- a/Infrastructure.Identity/Infrastructure.Identity.csproj
+++ b/Infrastructure.Identity/Infrastructure.Identity.csproj
@@ -1,23 +1,23 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.1.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.26" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.26" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.26" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.26" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.26">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="microsoft.extensions.dependencyinjection" Version="8.0.1" />
-    <PackageReference Include="MimeKit" Version="2.9.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.26" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="microsoft.extensions.dependencyinjection" Version="10.0.7" />
+    <PackageReference Include="MimeKit" Version="4.16.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />

--- a/Infrastructure.Persistence/Infrastructure.Persistence.csproj
+++ b/Infrastructure.Persistence/Infrastructure.Persistence.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.1.0</Version>
   </PropertyGroup>
   <ItemGroup>
@@ -8,10 +8,10 @@
     <Compile Remove="Migrations\20200627124316_Updates.Designer.cs" />
     <Compile Remove="Migrations\20200724180907_New.cs" />
     <Compile Remove="Migrations\20200724180907_New.Designer.cs" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.26" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.26" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.26" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />

--- a/Infrastructure.Shared/Infrastructure.Shared.csproj
+++ b/Infrastructure.Shared/Infrastructure.Shared.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.1.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />
-    <PackageReference Include="MailKit" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageReference Include="MimeKit" Version="2.9.1" />
+    <PackageReference Include="MailKit" Version="4.16.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
+    <PackageReference Include="MimeKit" Version="4.16.0" />
   </ItemGroup>
 </Project>

--- a/WebApi/Controllers/v1/ProductController.cs
+++ b/WebApi/Controllers/v1/ProductController.cs
@@ -9,6 +9,7 @@ using Application.Features.Products.Commands.UpdateProduct;
 using Application.Features.Products.Queries.GetAllProducts;
 using Application.Features.Products.Queries.GetProductById;
 using Application.Filters;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 

--- a/WebApi/Extensions/ServiceExtensions.cs
+++ b/WebApi/Extensions/ServiceExtensions.cs
@@ -1,10 +1,8 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Asp.Versioning;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace WebApi.Extensions
 {
@@ -54,17 +52,15 @@ namespace WebApi.Extensions
                 });
             });
         }
+
         public static void AddApiVersioningExtension(this IServiceCollection services)
         {
             services.AddApiVersioning(config =>
             {
-                // Specify the default API Version as 1.0
                 config.DefaultApiVersion = new ApiVersion(1, 0);
-                // If the client hasn't specified the API version in the request, use the default API version number 
                 config.AssumeDefaultVersionWhenUnspecified = true;
-                // Advertise the API versions supported for the particular endpoint
                 config.ReportApiVersions = true;
-            });
+            }).AddMvc();
         }
     }
 }

--- a/WebApi/WebApi.csproj
+++ b/WebApi/WebApi.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Authors>Mukesh Murugan</Authors>
     <Company>codewithmukesh</Company>
     <RepositoryUrl>https://github.com/iammukeshm/CleanArchitecture.WebApi</RepositoryUrl>
@@ -14,22 +14,22 @@
     <NoWarn>1701;1702;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.26">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.23" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.5.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
-    <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.1" />
-    <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.5.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.26" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="9.1.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
+    <PackageReference Include="Serilog.Enrichers.Process" Version="3.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="9.0.3" />
+    <PackageReference Include="Asp.Versioning.Mvc" Version="10.0.0" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />


### PR DESCRIPTION
# Executive Report: .NET Upgrade — CleanArchitecture.WebApi  
  
**Date:** 2026-05-11 | **Iteration:** 4  
  
---  
  
## 1. 📋 Executive Summary  
  
The `CleanArchitecture.WebApi` solution (6 projects, Clean Architecture / Onion pattern) was successfully upgraded from **net8.0 → net10.0**. The Microsoft .NET Upgrade Assistant automated the `TargetFramework` bump and Microsoft-owned package version lifts across all projects. Kiro CLI then resolved the remaining build failures caused by deprecated third-party packages and breaking API changes in MediatR, AutoMapper, and the API versioning library — achieving a **clean `dotnet build` with 0 errors**.  
  
---  
  
## 2. 🏗️ Application Changes  
  
- 🗂️ **6 projects** upgraded: `Domain`, `Application`, `Infrastructure.Persistence`, `Infrastructure.Identity`, `Infrastructure.Shared`, `WebApi`  
- 🎯 **Target framework** changed from `net8.0` → `net10.0` across all `.csproj` files  
- 📦 **NuGet packages** updated — Microsoft-owned packages auto-lifted by Upgrade Assistant; third-party packages resolved manually by Kiro  
- ✍️ **3 C# source files** required code-level changes to align with breaking API changes in upgraded libraries  
- 🔐 **Security vulnerabilities** remediated: high-severity `AutoMapper` 10.x, moderate `MailKit`/`MimeKit` 2.x, moderate `Swashbuckle` 5.x  
  
---  
  
## 3. 🛠️ Tools Used  
  
| Tool | Version | Role |  
|---|---|---|  
| 🔷 **.NET SDK** | `10.0.203` | Compiler, build, restore |  
| 🤖 **.NET Upgrade Assistant** | `1.0.518.26217` | Automated `TargetFramework` bump + Microsoft package lifts |  
| 🪄 **Kiro CLI** | `2.0.1` (claude-sonnet-4-5) | Resolved third-party package conflicts, breaking API changes, and build errors |  
  
- ⚙️ Upgrade Assistant ran in **non-interactive / inplace** mode across all 6 projects  
- ⚠️ Upgrade Assistant noted `Msbuild was not found` during build verification steps — Kiro CLI compensated by running `dotnet build` directly  
- 🔁 Kiro iterated through **4 build cycles** to reach zero errors  
  
---  
  
## 4. 💻 Code Changes  
  
### Package updates  
  
| Project | Change |  
|---|---|  
| `Infrastructure.Identity` | `System.IdentityModel.Tokens.Jwt` 7.1.2 → **8.0.1** (NU1605 conflict fix); `MimeKit` 2.9.1 → **4.16.0** |  
| `Application` | `MediatR.Extensions.Microsoft.DependencyInjection` 8.1.0 + implicit MediatR 8 → **`MediatR` 14.1.0**; `AutoMapper` 10.0.0 → **16.1.1** (removed separate DI extensions package, merged in v13+); `FluentValidation`/`FluentValidation.DependencyInjectionExtensions` 9.1.2 → **11.4.0**; removed redundant `System.Text.Json` (built-in to net10.0) |  
| `WebApi` | `Swashbuckle.AspNetCore` 5.5.1 → **8.1.1** (v10.x uses Microsoft.OpenApi 2.x with breaking API changes); `Serilog.AspNetCore` 3.4.0 → **10.0.0**; Serilog enrichers/settings → latest; `Serilog.Sinks.MSSqlServer` 5.5.1 → **9.0.3**; `Microsoft.AspNetCore.Mvc.Versioning` 4.1.1 (deprecated, max net5.0) → **`Asp.Versioning.Mvc` + `Asp.Versioning.Mvc.ApiExplorer` 10.0.0**; `FluentValidation.AspNetCore` 9.1.2 → **11.3.1** |  
| `Infrastructure.Shared` | `MailKit` 2.8.0 → **4.16.0**; `MimeKit` 2.9.1 → **4.16.0** |  
  
### Source file changes  
  
| File | Change |  
|---|---|  
| `Application/ServiceExtensions.cs` | `AddMediatR(Assembly)` → `AddMediatR(cfg => cfg.RegisterServicesFromAssembly(...))` (MediatR 12+ API); `AddAutoMapper(Assembly)` → `AddAutoMapper(cfg => cfg.AddMaps(...))` (AutoMapper 13+ API) |  
| `Application/Behaviours/ValidationBehaviour.cs` | `Handle(request, cancellationToken, next)` → `Handle(request, next, cancellationToken)` (MediatR 12+ parameter order change) |  
| `WebApi/Extensions/ServiceExtensions.cs` | Added `using Asp.Versioning`; `AddApiVersioning(...)` → `AddApiVersioning(...).AddMvc()` (fluent builder pattern) |  
| `WebApi/Controllers/v1/ProductController.cs` | Added `using Asp.Versioning` for `[ApiVersion]` attribute resolution |  
  
---  
  
## 5. ⏱️ Time Savings Estimate  
  
| Activity | Manual Estimate | Automated |  
|---|---|---|  
| `TargetFramework` + Microsoft package lifts (6 projects) | ~2 hrs | ✅ Upgrade Assistant (~2 min) |  
| Third-party package conflict research & resolution | ~3 hrs | ✅ Kiro CLI (~4 min) |  
| Breaking API changes (MediatR, AutoMapper, Versioning) | ~2 hrs | ✅ Kiro CLI (~4 min) |  
| Iterative build-fix cycles | ~1 hr | ✅ Kiro CLI (~1 min) |  
| **Total** | **~8 hrs** | **~11 min** |  
  
- 💡 **Estimated time saved: ~7.5–8 hours** of developer effort  
- 🚀 End-to-end wall-clock time: **~9 minutes** (per log timestamp)  
  
---  
  
## 6. ➡️ Next Steps  
  
### ✅ Validation  
- 🧪 Run integration tests against the upgraded solution (no test project currently exists — recommend adding one)  
- 🗄️ Run `dotnet ef database update` for both `ApplicationDbContext` and `IdentityContext` to verify EF Core migrations are compatible with net10.0  
- 🌐 Smoke-test key endpoints: `/api/account/authenticate`, `/api/v1/product`, `/health`, `/swagger`  
- 🔑 Verify JWT authentication flow end-to-end with the updated `System.IdentityModel.Tokens.Jwt` 8.x  
  
### 🔧 Improvement Recommendations  
- 📝 **Add a test project** — no unit or integration tests exist; this is a significant gap for a production upgrade  
- 🔄 **Upgrade Swashbuckle to 10.x** — currently pinned to 8.1.1 to avoid `Microsoft.OpenApi` 2.x breaking changes; migrate Swagger config to the new API when time permits  
- 🛡️ **Address remaining low-severity warnings** — `NuGet.Packaging`/`NuGet.Protocol` vulnerabilities are transitive from `Microsoft.VisualStudio.Web.CodeGeneration.Design`; consider removing that package from production builds  
- 🐳 **Containerize for net10.0** — update `Dockerfile` base images from `mcr.microsoft.com/dotnet/aspnet:8.0` to `mcr.microsoft.com/dotnet/aspnet:10.0`  
- 🔒 **Rotate JWT key** — `appsettings.json` contains a hardcoded JWT signing key; move to environment variables or Azure Key Vault  
- 📊 **Enable nullable reference types** — net10.0 projects benefit from `<Nullable>enable</Nullable>` for improved null safety  
