### PR TITLE
Upgrade .NET version to 10 on iteration 5

### DIFF
--- a/Application/Application.csproj
+++ b/Application/Application.csproj
@@ -4,15 +4,13 @@
     <Version>1.1.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+    <PackageReference Include="AutoMapper" Version="16.1.1" />
     <PackageReference Include="FluentValidation" Version="11.11.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Text.Json" Version="10.0.9" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Domain\Domain.csproj" />

--- a/Application/ServiceExtensions.cs
+++ b/Application/ServiceExtensions.cs
@@ -15,7 +15,7 @@ namespace Application
     {
         public static void AddApplicationLayer(this IServiceCollection services)
         {
-            services.AddAutoMapper(Assembly.GetExecutingAssembly());
+            services.AddAutoMapper(cfg => cfg.AddMaps(Assembly.GetExecutingAssembly()));
             services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
             services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()));
             services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));

--- a/Domain/Domain.csproj
+++ b/Domain/Domain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.1.0</Version>
   </PropertyGroup>
 

--- a/Infrastructure.Identity/ServiceExtensions.cs
+++ b/Infrastructure.Identity/ServiceExtensions.cs
@@ -15,7 +15,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json;
 using System;
-using System.Reflection.Metadata.Ecma335;
 using System.Text;
 using System.Threading.Tasks;
 

--- a/Infrastructure.Shared/Infrastructure.Shared.csproj
+++ b/Infrastructure.Shared/Infrastructure.Shared.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />
-    <PackageReference Include="MailKit" Version="4.12.0" />
+    <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
-    <PackageReference Include="MimeKit" Version="4.12.0" />
+    <PackageReference Include="MimeKit" Version="4.17.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# .NET Upgrade Executive Report — Iteration 5  
**Project:** CleanArchitecture.WebApi | **Date:** 2026-06-29  
  
---  
  
## 🎯 Executive Summary  
  
The `CleanArchitecture.WebApi` solution (ASP.NET Core 3.1 Clean Architecture boilerplate) was successfully upgraded to **.NET 10.0** with **zero compilation errors and zero warnings**. The Microsoft .NET Upgrade Assistant performed the initial project-file scaffolding (target framework detection and SDK-style transforms), and Kiro CLI completed the remaining work — resolving package vulnerability advisories, fixing the `Domain` project that was left on `netstandard2.1`, adapting to breaking API changes in AutoMapper 16, and removing stale dependencies. All 6 projects now build cleanly in both Debug and Release configurations.  
  
---  
  
## 📦 Application Changes  
  
- 🏗️ **Solution:** `CleanArchitecture.WebApi.sln` — 6-project Clean Architecture solution (Domain, Application, Infrastructure.Persistence, Infrastructure.Identity, Infrastructure.Shared, WebApi)  
- 🎯 **Target framework:** All projects unified on `net10.0` (previously split across `netstandard2.1` and `net10.0`)  
- ✅ **Build result:** `0 Error(s)` · `0 Warning(s)` — Release configuration verified  
  
---  
  
## 🛠️ Tools Used  
  
- 🔧 **.NET SDK** — `dotnet build` used for iterative compilation and validation  
- 🤖 **Microsoft .NET Upgrade Assistant** `v1.0.518.26217` — automated target framework detection, SDK-style project transforms, and C# namespace/attribute code scanning across Domain project files  
- 🤖 **Kiro CLI** `v2.0.1` (claude-sonnet-4-5) — autonomous error triage, NuGet vulnerability remediation, breaking-change adaptation, and final build verification  
  
---  
  
## 🔨 Code Changes  
  
| File | Change |  
|---|---|  
| `Domain/Domain.csproj` | 🎯 `netstandard2.1` → `net10.0` |  
| `Application/Application.csproj` | ⬆️ `AutoMapper` 12.0.1 → 16.1.1 (fixes GHSA-rvv3-g6hj-g44x) |  
| `Application/Application.csproj` | 🗑️ Removed `AutoMapper.Extensions.Microsoft.DependencyInjection` (absorbed into AutoMapper 13+) |  
| `Application/Application.csproj` | 🗑️ Removed redundant `System.Text.Json` (built into net10.0 framework) |  
| `Application/ServiceExtensions.cs` | 🔧 Updated `AddAutoMapper` call to AutoMapper 16 API: `cfg.AddMaps(Assembly.GetExecutingAssembly())` |  
| `Infrastructure.Shared/Infrastructure.Shared.csproj` | ⬆️ `MailKit` 4.12.0 → 4.17.0 (fixes GHSA-9j88-vvj5-vhgr) |  
| `Infrastructure.Shared/Infrastructure.Shared.csproj` | ⬆️ `MimeKit` 4.12.0 → 4.17.0 (fixes GHSA-g7hc-96xr-gvvx) |  
| `Infrastructure.Identity/ServiceExtensions.cs` | 🧹 Removed unused `using System.Reflection.Metadata.Ecma335` |  
  
**Security advisories resolved:** 3 (1 high severity, 2 moderate severity)  
  
---  
  
## ⏱️ Time Savings Estimate  
  
| Task | Manual Estimate | Automated |  
|---|---|---|  
| Project file framework analysis & upgrade (6 projects) | 2–3 hrs | ~2 min (Upgrade Assistant) |  
| NuGet vulnerability triage + package research | 1–2 hrs | ~5 min (Kiro CLI) |  
| AutoMapper 12→16 breaking change diagnosis & fix | 2–4 hrs | ~3 min (Kiro CLI) |  
| Dependency cleanup (unused usings, redundant refs) | 30 min | ~1 min (Kiro CLI) |  
| Iterative build-fix-verify cycle | 3–5 hrs | ~6 min total |  
| **Total** | **8.5–14.5 hrs** | **~17 min** |  
  
> 💡 **Estimated saving: ~8–14 hours** of developer time for a developer unfamiliar with the AutoMapper 16 API changes and .NET 10 package compatibility matrix.  
  
---  
  
## ➡️ Next Steps  
  
### Validation  
- 🧪 Run integration tests against the upgraded solution (no test project exists — see below)  
- 🔍 Verify EF Core migrations still apply cleanly: `dotnet ef database update` for both `ApplicationDbContext` and `IdentityContext`  
- 🚀 Smoke-test the API endpoints: `/api/account/authenticate`, `/api/v1/product`, `/health`  
- 🐳 Validate Docker/container build if a `Dockerfile` is used in deployment  
  
### Recommendations  
- ⚠️ **Add a test project** — the solution has no unit or integration tests; this is a significant risk for future upgrades  
- 🔑 **Rotate JWT signing key** — `appsettings.json` contains a plain-text `JWTSettings:Key`; move to environment variables or secrets management  
- 🛡️ **Replace `Startup.cs` pattern** with minimal hosting (`WebApplication.CreateBuilder`) — the legacy `Startup`/`Program` split works but is the pre-.NET 6 pattern  
- 📧 **Email service credentials** — `MailSettings` configuration should be validated before deploying to production  
- 🔄 **AutoMapper → Mapster** — consider evaluating `Mapster` as a faster, actively-maintained alternative now that AutoMapper has recurring CVEs  
- 📌 **Pin EF Core migration target** — existing migrations were generated on `netcoreapp3.1`; regenerating them under `net10.0` ensures long-term compatibility  
