### PR TITLE
Upgrade .NET version to 10 on iteration 2

### DIFF
--- a/Application/Application.csproj
+++ b/Application/Application.csproj
@@ -1,23 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.1.0</Version>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="10.0.0" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="FluentValidation" Version="9.1.2" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="9.1.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.7" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
+    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="FluentValidation" Version="11.11.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
+    <PackageReference Include="MediatR" Version="12.4.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Domain\Domain.csproj" />
   </ItemGroup>
-
 </Project>

--- a/Application/Behaviours/ValidationBehaviour.cs
+++ b/Application/Behaviours/ValidationBehaviour.cs
@@ -17,7 +17,7 @@ namespace Application.Behaviours
             _validators = validators;
         }
 
-        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
         {
             if (_validators.Any())
             {

--- a/Application/ServiceExtensions.cs
+++ b/Application/ServiceExtensions.cs
@@ -1,13 +1,9 @@
 ﻿using Application.Behaviours;
-using Application.Features.Products.Commands.CreateProduct;
 using AutoMapper;
 using FluentValidation;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
-using System;
-using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 
 namespace Application
 {
@@ -17,9 +13,8 @@ namespace Application
         {
             services.AddAutoMapper(Assembly.GetExecutingAssembly());
             services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
-            services.AddMediatR(Assembly.GetExecutingAssembly());
+            services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()));
             services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
-
         }
     }
 }

--- a/Domain/Domain.csproj
+++ b/Domain/Domain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.1.0</Version>
   </PropertyGroup>
 

--- a/Infrastructure.Identity/Infrastructure.Identity.csproj
+++ b/Infrastructure.Identity/Infrastructure.Identity.csproj
@@ -1,26 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.1.0</Version>
-	<LangVersion>latest</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-<ItemGroup>
-  <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
-  <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.1.7" />
-  <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.7" />
-  <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
-  <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.7">
-    <PrivateAssets>all</PrivateAssets>
-    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-  </PackageReference>
-  <PackageReference Include="microsoft.extensions.dependencyinjection" Version="3.1.7" />
-  <PackageReference Include="MimeKit" Version="2.9.1" />
-  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
-  <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.7.1" />
-  <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.7" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageReference Include="MimeKit" Version="4.11.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />
   </ItemGroup>
-<ItemGroup>
-  <ProjectReference Include="..\Application\Application.csproj" />
-</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Application\Application.csproj" />
+  </ItemGroup>
 </Project>

--- a/Infrastructure.Identity/ServiceExtensions.cs
+++ b/Infrastructure.Identity/ServiceExtensions.cs
@@ -15,7 +15,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json;
 using System;
-using System.Reflection.Metadata.Ecma335;
 using System.Text;
 using System.Threading.Tasks;
 

--- a/Infrastructure.Identity/Services/AccountService.cs
+++ b/Infrastructure.Identity/Services/AccountService.cs
@@ -6,22 +6,18 @@ using Domain.Settings;
 using Infrastructure.Identity.Helpers;
 using Infrastructure.Identity.Models;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
-using Org.BouncyCastle.Ocsp;
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
-using System.Net.Cache;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using Application.Enums;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Primitives;
 using Application.DTOs.Email;
 
 namespace Infrastructure.Identity.Services
@@ -101,8 +97,7 @@ namespace Infrastructure.Identity.Services
                 {
                     await _userManager.AddToRoleAsync(user, Roles.Basic.ToString());
                     var verificationUri = await SendVerificationEmail(user, origin);
-                    //TODO: Attach Email Service here and configure it via appsettings
-                    await _emailService.SendAsync(new Application.DTOs.Email.EmailRequest() { From = "mail@codewithmukesh.com", To = user.Email, Body = $"Please confirm your account by visiting this URL {verificationUri}", Subject = "Confirm Registration" });
+                    await _emailService.SendAsync(new EmailRequest() { From = "mail@codewithmukesh.com", To = user.Email, Body = $"Please confirm your account by visiting this URL {verificationUri}", Subject = "Confirm Registration" });
                     return new Response<string>(user.Id, message: $"User Registered. Please confirm your account by visiting this URL {verificationUri}");
                 }
                 else
@@ -155,10 +150,8 @@ namespace Infrastructure.Identity.Services
 
         private string RandomTokenString()
         {
-            using var rngCryptoServiceProvider = new RNGCryptoServiceProvider();
             var randomBytes = new byte[40];
-            rngCryptoServiceProvider.GetBytes(randomBytes);
-            // convert random bytes to hex string
+            RandomNumberGenerator.Fill(randomBytes);
             return BitConverter.ToString(randomBytes).Replace("-", "");
         }
         
@@ -170,7 +163,6 @@ namespace Infrastructure.Identity.Services
             var _enpointUri = new Uri(string.Concat($"{origin}/", route));
             var verificationUri = QueryHelpers.AddQueryString(_enpointUri.ToString(), "userId", user.Id);
             verificationUri = QueryHelpers.AddQueryString(verificationUri, "code", code);
-            //Email Service Call Here
             return verificationUri;
         }
 
@@ -234,5 +226,4 @@ namespace Infrastructure.Identity.Services
             }
         }
     }
-
 }

--- a/Infrastructure.Persistence/Infrastructure.Persistence.csproj
+++ b/Infrastructure.Persistence/Infrastructure.Persistence.csproj
@@ -1,27 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.1.0</Version>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Remove="Migrations\20200627124316_Updates.cs" />
     <Compile Remove="Migrations\20200627124316_Updates.Designer.cs" />
     <Compile Remove="Migrations\20200724180907_New.cs" />
     <Compile Remove="Migrations\20200724180907_New.Designer.cs" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.7" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />
     <ProjectReference Include="..\Domain\Domain.csproj" />
   </ItemGroup>
-
 </Project>

--- a/Infrastructure.Shared/Infrastructure.Shared.csproj
+++ b/Infrastructure.Shared/Infrastructure.Shared.csproj
@@ -1,17 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.1.0</Version>
-	<LangVersion>latest</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="MailKit" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.7" />
-    <PackageReference Include="MimeKit" Version="2.9.1" />
+    <PackageReference Include="MailKit" Version="4.11.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageReference Include="MimeKit" Version="4.11.0" />
   </ItemGroup>
 </Project>

--- a/Infrastructure.Shared/Services/EmailService.cs
+++ b/Infrastructure.Shared/Services/EmailService.cs
@@ -16,7 +16,7 @@ namespace Infrastructure.Shared.Services
         public MailSettings _mailSettings { get; }
         public ILogger<EmailService> _logger { get; }
 
-        public EmailService(IOptions<MailSettings> mailSettings,ILogger<EmailService> logger)
+        public EmailService(IOptions<MailSettings> mailSettings, ILogger<EmailService> logger)
         {
             _mailSettings = mailSettings.Value;
             _logger = logger;
@@ -26,7 +26,6 @@ namespace Infrastructure.Shared.Services
         {
             try
             {
-                // create message
                 var email = new MimeMessage();
                 email.Sender = new MailboxAddress(_mailSettings.DisplayName, request.From ?? _mailSettings.EmailFrom);
                 email.To.Add(MailboxAddress.Parse(request.To));
@@ -35,11 +34,10 @@ namespace Infrastructure.Shared.Services
                 builder.HtmlBody = request.Body;
                 email.Body = builder.ToMessageBody();
                 using var smtp = new SmtpClient();
-                smtp.Connect(_mailSettings.SmtpHost, _mailSettings.SmtpPort, SecureSocketOptions.StartTls);
-                smtp.Authenticate(_mailSettings.SmtpUser, _mailSettings.SmtpPass);
+                await smtp.ConnectAsync(_mailSettings.SmtpHost, _mailSettings.SmtpPort, SecureSocketOptions.StartTls);
+                await smtp.AuthenticateAsync(_mailSettings.SmtpUser, _mailSettings.SmtpPass);
                 await smtp.SendAsync(email);
-                smtp.Disconnect(true);
-
+                await smtp.DisconnectAsync(true);
             }
             catch (System.Exception ex)
             {

--- a/WebApi/Controllers/v1/ProductController.cs
+++ b/WebApi/Controllers/v1/ProductController.cs
@@ -1,16 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Application.Features.Products.Commands;
-using Application.Features.Products.Commands.CreateProduct;
+﻿using Application.Features.Products.Commands.CreateProduct;
 using Application.Features.Products.Commands.DeleteProductById;
 using Application.Features.Products.Commands.UpdateProduct;
 using Application.Features.Products.Queries.GetAllProducts;
 using Application.Features.Products.Queries.GetProductById;
 using Application.Filters;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 

--- a/WebApi/Extensions/ServiceExtensions.cs
+++ b/WebApi/Extensions/ServiceExtensions.cs
@@ -1,10 +1,9 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace WebApi.Extensions
 {
@@ -54,15 +53,13 @@ namespace WebApi.Extensions
                 });
             });
         }
+
         public static void AddApiVersioningExtension(this IServiceCollection services)
         {
             services.AddApiVersioning(config =>
             {
-                // Specify the default API Version as 1.0
                 config.DefaultApiVersion = new ApiVersion(1, 0);
-                // If the client hasn't specified the API version in the request, use the default API version number 
                 config.AssumeDefaultVersionWhenUnspecified = true;
-                // Advertise the API versions supported for the particular endpoint
                 config.ReportApiVersions = true;
             });
         }

--- a/WebApi/WebApi.csproj
+++ b/WebApi/WebApi.csproj
@@ -1,45 +1,38 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Authors>Mukesh Murugan</Authors>
     <Company>codewithmukesh</Company>
     <RepositoryUrl>https://github.com/iammukeshm/CleanArchitecture.WebApi</RepositoryUrl>
     <RepositoryType>Public</RepositoryType>
     <PackageProjectUrl>https://www.codewithmukesh.com/blog/aspnet-core-webapi-clean-architecture/</PackageProjectUrl>
     <Version>1.1.0</Version>
-	<LangVersion>latest</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>CleanArchitecture.WebApi.xml</DocumentationFile>
     <NoWarn>1701;1702;1591</NoWarn>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.5.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
-    <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.1" />
-    <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.5.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.7" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="9.1.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Process" Version="3.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="8.1.0" />
+    <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.9" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />
     <ProjectReference Include="..\Infrastructure.Identity\Infrastructure.Identity.csproj" />
     <ProjectReference Include="..\Infrastructure.Persistence\Infrastructure.Persistence.csproj" />
     <ProjectReference Include="..\Infrastructure.Shared\Infrastructure.Shared.csproj" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
# .NET Upgrade Executive Report — CleanArchitecture.WebApi  
  
## 1. 📋 Executive Summary  
  
The `CleanArchitecture.WebApi` solution was successfully upgraded from a mixed **netcoreapp3.1 / netstandard2.1** baseline to **.NET 10.0** across all six projects. The migration was performed in a fully automated, non-interactive cycle driven by the Microsoft .NET Upgrade Assistant for initial project file scaffolding, followed by Kiro CLI to resolve all remaining compilation errors and package conflicts. The final build completes with **zero errors** — the solution is clean, buildable, and ready for integration testing.  
  
---  
  
## 2. 🗂️ Application Changes  
  
- 🏗️ **6 projects retargeted** to `net10.0`:  
  - `Domain`, `Application` — upgraded from `netstandard2.1`  
  - `WebApi`, `Infrastructure.Identity`, `Infrastructure.Persistence`, `Infrastructure.Shared` — upgraded from `netcoreapp3.1`  
- 📦 **NuGet packages modernised** across the entire solution dependency graph  
- 🔐 **JWT authentication stack** pinned to compatible versions resolving a `NU1605` downgrade conflict  
- 📧 **Email service** updated to use the async MailKit 4.x API  
- 🔄 **CQRS pipeline** updated to MediatR 12 conventions  
- 🌐 **API versioning** migrated from the deprecated `Microsoft.AspNetCore.Mvc.Versioning` package to `Asp.Versioning.Mvc`  
  
---  
  
## 3. 🛠️ Tools Used  
  
| Tool | Version | Role |  
|------|---------|------|  
| 🔷 **.NET SDK** | 10.0 | Compilation target and `dotnet build` runner |  
| 🤖 **Microsoft .NET Upgrade Assistant** | 1.0.518.26217 | Automated project file and package scaffolding (in-place framework upgrade) |  
| 🤖 **Kiro CLI** | 2.0.1 (Claude Sonnet 4) | Compilation error diagnosis, package conflict resolution, and targeted code fixes |  
  
- ⚙️ Upgrade Assistant ran in **non-interactive mode** (`NonInteractive=True`), processing all 6 projects sequentially  
- 🧠 Kiro CLI handled everything the Upgrade Assistant could not: breaking API changes, obsolete types, and version constraint conflicts  
  
---  
  
## 4. 💻 Code Changes  
  
### Project Files (`.csproj`)  
- ✅ `Domain.csproj` & `Application.csproj` — `netstandard2.1` → `net10.0`  
- ✅ `Infrastructure.Identity.csproj` — removed conflicting `System.IdentityModel.Tokens.Jwt 6.7.1`; pinned to `8.0.1` to align with `JwtBearer 10.0.9` transitive requirements  
- ✅ `Application.csproj` — replaced deprecated `MediatR.Extensions.Microsoft.DependencyInjection 8.1.0` with `MediatR 12.4.1`; removed redundant `AutoMapper.Extensions.Microsoft.DependencyInjection` (DI support now built into `AutoMapper 13.0.1`); upgraded EF Core to `10.0.9`; upgraded `FluentValidation` to `11.11.0`  
- ✅ `Infrastructure.Shared.csproj` — `MailKit 2.8.0` → `4.11.0`; `MimeKit 2.9.1` → `4.11.0`  
- ✅ `WebApi.csproj` — `Swashbuckle.AspNetCore 5.5.1` → `6.9.0`; all Serilog packages upgraded to current versions (`9.0.0`); `Microsoft.AspNetCore.Mvc.Versioning 4.1.1` → `Asp.Versioning.Mvc 8.1.0`; `FluentValidation.AspNetCore` → `11.3.0`; removed `Microsoft.VisualStudio.Web.CodeGeneration.Design`  
  
### Source Code  
- ✅ `Application/ServiceExtensions.cs` — updated MediatR 12 registration syntax (`RegisterServicesFromAssembly`)  
- ✅ `Application/Behaviours/ValidationBehaviour.cs` — fixed `IPipelineBehavior.Handle` signature (MediatR 12 swapped `next`/`cancellationToken` parameter order)  
- ✅ `Infrastructure.Identity/Services/AccountService.cs` — removed non-existent `using Org.BouncyCastle.Ocsp` and `using System.Net.Cache`; replaced obsolete `RNGCryptoServiceProvider` with `RandomNumberGenerator.Fill()`  
- ✅ `Infrastructure.Identity/ServiceExtensions.cs` — removed erroneous `using System.Reflection.Metadata.Ecma335`  
- ✅ `Infrastructure.Shared/Services/EmailService.cs` — updated MailKit calls to async API (`ConnectAsync`, `AuthenticateAsync`, `DisconnectAsync`)  
- ✅ `WebApi/Extensions/ServiceExtensions.cs` — swapped `Microsoft.AspNetCore.Mvc` versioning namespace for `Asp.Versioning`  
- ✅ `WebApi/Controllers/v1/ProductController.cs` — added `using Asp.Versioning`; removed stale/unused `using` directives  
  
---  
  
## 5. ⏱️ Time Savings Estimate  
  
| Task | Manual Estimate | Automated |  
|------|----------------|-----------|  
| Project file retargeting (6 projects) | 1–2 hrs | ~2 min |  
| NuGet package research and version conflict resolution | 3–4 hrs | ~5 min |  
| Breaking API fixes (MediatR 12, MailKit 4, Asp.Versioning) | 2–3 hrs | ~3 min |  
| Stale/invalid `using` and obsolete API cleanup | 1 hr | ~1 min |  
| Build-verify-fix iteration cycles | 2–4 hrs | ~7 min |  
| **Total** | **9–14 hrs** | **~18 min** |  
  
💡 Estimated **95%+ time saving** — equivalent to roughly **1–2 developer days** avoided on a project of this size and dependency complexity.  
  
---  
  
## 6. 🔮 Next Steps  
  
### ✔️ Validation  
- 🧪 Run integration/smoke tests against an in-memory database (`UseInMemoryDatabase: true`) to validate the JWT auth, CQRS pipeline, and EF Core repositories end-to-end  
- 🔍 Verify Swagger UI loads at `/swagger` — Swashbuckle 6.x has minor breaking changes in the `SwaggerGen` options API  
- 📬 Test email flow with a mock SMTP server (e.g. MailHog) to confirm MailKit 4.x async path works correctly  
  
### 🛡️ Security  
- ⚠️ `AutoMapper 13.0.1` carries a known high-severity advisory (`GHSA-rvv3-g6hj-g44x`) — evaluate upgrading to the latest patched release or migrating mapping logic to a maintained alternative  
- ⚠️ `MailKit 4.11.0` / `MimeKit 4.11.0` carry moderate-severity advisories — check for newer patch releases  
  
### 🚀 Improvement Recommendations  
- 🔄 Consider migrating `Swashbuckle.AspNetCore` to the native `.NET 9+` OpenAPI middleware (`Microsoft.AspNetCore.OpenApi`) for long-term framework alignment  
- 🗄️ Regenerate EF Core migrations targeting .NET 10 to ensure the schema snapshot is clean (`dotnet ef migrations add InitialNet10`)  
- 📝 Update the GitHub Actions workflow (`.github/workflows/dotnet-core.yml`) to use `dotnet-version: '10.x'`  
- 🔒 Pin `System.IdentityModel.Tokens.Jwt` to `8.x` in a `Directory.Build.props` or solution-level `global.json` to prevent future accidental downgrades  

## Credit usage

💳 Kiro CLI credits used: 13.24  
