### PR TITLE
Upgrade .NET version to 10 on iteration 6

### DIFF
--- a/Application/Application.csproj
+++ b/Application/Application.csproj
@@ -1,23 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.1.0</Version>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="10.0.0" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="FluentValidation" Version="9.1.2" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="9.1.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.7" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
+    <PackageReference Include="AutoMapper" Version="12.0.1" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+    <PackageReference Include="FluentValidation" Version="11.11.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
+    <PackageReference Include="MediatR" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Domain\Domain.csproj" />
   </ItemGroup>
-
 </Project>

--- a/Application/Behaviours/ValidationBehaviour.cs
+++ b/Application/Behaviours/ValidationBehaviour.cs
@@ -1,4 +1,4 @@
-﻿using FluentValidation;
+using FluentValidation;
 using MediatR;
 using System.Collections.Generic;
 using System.Linq;
@@ -17,7 +17,7 @@ namespace Application.Behaviours
             _validators = validators;
         }
 
-        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
         {
             if (_validators.Any())
             {

--- a/Application/Features/Products/Commands/CreateProduct/CreateProductCommandValidator.cs
+++ b/Application/Features/Products/Commands/CreateProduct/CreateProductCommandValidator.cs
@@ -1,11 +1,5 @@
-﻿using Application.Interfaces.Repositories;
-using Domain.Entities;
+using Application.Interfaces.Repositories;
 using FluentValidation;
-using Microsoft.EntityFrameworkCore.Internal;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/Application/Interfaces/IAccountService.cs
+++ b/Application/Interfaces/IAccountService.cs
@@ -1,9 +1,5 @@
-﻿using Application.DTOs.Account;
+using Application.DTOs.Account;
 using Application.Wrappers;
-using Microsoft.Extensions.Primitives;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Application.Interfaces

--- a/Application/ServiceExtensions.cs
+++ b/Application/ServiceExtensions.cs
@@ -1,13 +1,9 @@
-﻿using Application.Behaviours;
-using Application.Features.Products.Commands.CreateProduct;
+using Application.Behaviours;
 using AutoMapper;
 using FluentValidation;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
-using System;
-using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 
 namespace Application
 {
@@ -17,9 +13,8 @@ namespace Application
         {
             services.AddAutoMapper(Assembly.GetExecutingAssembly());
             services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
-            services.AddMediatR(Assembly.GetExecutingAssembly());
+            services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()));
             services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
-
         }
     }
 }

--- a/Domain/Domain.csproj
+++ b/Domain/Domain.csproj
@@ -1,8 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.1.0</Version>
   </PropertyGroup>
-
 </Project>

--- a/Infrastructure.Identity/Infrastructure.Identity.csproj
+++ b/Infrastructure.Identity/Infrastructure.Identity.csproj
@@ -1,26 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.1.0</Version>
-	<LangVersion>latest</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-<ItemGroup>
-  <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
-  <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.1.7" />
-  <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.7" />
-  <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
-  <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.7">
-    <PrivateAssets>all</PrivateAssets>
-    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-  </PackageReference>
-  <PackageReference Include="microsoft.extensions.dependencyinjection" Version="3.1.7" />
-  <PackageReference Include="MimeKit" Version="2.9.1" />
-  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
-  <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.7.1" />
-  <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.7" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>
-<ItemGroup>
-  <ProjectReference Include="..\Application\Application.csproj" />
-</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Application\Application.csproj" />
+  </ItemGroup>
 </Project>

--- a/Infrastructure.Identity/Seeds/DefaultSuperAdmin.cs
+++ b/Infrastructure.Identity/Seeds/DefaultSuperAdmin.cs
@@ -1,12 +1,7 @@
 ﻿using Application.Enums;
 using Infrastructure.Identity.Models;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.Extensions.Logging;
-using Org.BouncyCastle.Crypto.Prng.Drbg;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Infrastructure.Identity.Seeds

--- a/Infrastructure.Identity/Services/AccountService.cs
+++ b/Infrastructure.Identity/Services/AccountService.cs
@@ -1,4 +1,4 @@
-﻿using Application.DTOs.Account;
+using Application.DTOs.Account;
 using Application.Exceptions;
 using Application.Interfaces;
 using Application.Wrappers;
@@ -6,22 +6,18 @@ using Domain.Settings;
 using Infrastructure.Identity.Helpers;
 using Infrastructure.Identity.Models;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
-using Org.BouncyCastle.Ocsp;
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
-using System.Net.Cache;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using Application.Enums;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Primitives;
 using Application.DTOs.Email;
 
 namespace Infrastructure.Identity.Services
@@ -155,9 +151,8 @@ namespace Infrastructure.Identity.Services
 
         private string RandomTokenString()
         {
-            using var rngCryptoServiceProvider = new RNGCryptoServiceProvider();
             var randomBytes = new byte[40];
-            rngCryptoServiceProvider.GetBytes(randomBytes);
+            RandomNumberGenerator.Fill(randomBytes);
             // convert random bytes to hex string
             return BitConverter.ToString(randomBytes).Replace("-", "");
         }

--- a/Infrastructure.Persistence/Infrastructure.Persistence.csproj
+++ b/Infrastructure.Persistence/Infrastructure.Persistence.csproj
@@ -1,27 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.1.0</Version>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Remove="Migrations\20200627124316_Updates.cs" />
     <Compile Remove="Migrations\20200627124316_Updates.Designer.cs" />
     <Compile Remove="Migrations\20200724180907_New.cs" />
     <Compile Remove="Migrations\20200724180907_New.Designer.cs" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.7" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />
     <ProjectReference Include="..\Domain\Domain.csproj" />
   </ItemGroup>
-
 </Project>

--- a/Infrastructure.Shared/Infrastructure.Shared.csproj
+++ b/Infrastructure.Shared/Infrastructure.Shared.csproj
@@ -1,17 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.1.0</Version>
-	<LangVersion>latest</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="MailKit" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.7" />
-    <PackageReference Include="MimeKit" Version="2.9.1" />
+    <PackageReference Include="MailKit" Version="4.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageReference Include="MimeKit" Version="4.12.0" />
   </ItemGroup>
 </Project>

--- a/WebApi/Controllers/v1/ProductController.cs
+++ b/WebApi/Controllers/v1/ProductController.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Application.Features.Products.Commands;
+using Asp.Versioning;
 using Application.Features.Products.Commands.CreateProduct;
 using Application.Features.Products.Commands.DeleteProductById;
 using Application.Features.Products.Commands.UpdateProduct;
@@ -11,6 +7,7 @@ using Application.Features.Products.Queries.GetProductById;
 using Application.Filters;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 

--- a/WebApi/Extensions/ServiceExtensions.cs
+++ b/WebApi/Extensions/ServiceExtensions.cs
@@ -1,10 +1,9 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace WebApi.Extensions
 {
@@ -54,6 +53,7 @@ namespace WebApi.Extensions
                 });
             });
         }
+
         public static void AddApiVersioningExtension(this IServiceCollection services)
         {
             services.AddApiVersioning(config =>
@@ -64,7 +64,7 @@ namespace WebApi.Extensions
                 config.AssumeDefaultVersionWhenUnspecified = true;
                 // Advertise the API versions supported for the particular endpoint
                 config.ReportApiVersions = true;
-            });
+            }).AddMvc();
         }
     }
 }

--- a/WebApi/WebApi.csproj
+++ b/WebApi/WebApi.csproj
@@ -1,45 +1,39 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Authors>Mukesh Murugan</Authors>
     <Company>codewithmukesh</Company>
     <RepositoryUrl>https://github.com/iammukeshm/CleanArchitecture.WebApi</RepositoryUrl>
     <RepositoryType>Public</RepositoryType>
     <PackageProjectUrl>https://www.codewithmukesh.com/blog/aspnet-core-webapi-clean-architecture/</PackageProjectUrl>
     <Version>1.1.0</Version>
-	<LangVersion>latest</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>CleanArchitecture.WebApi.xml</DocumentationFile>
     <NoWarn>1701;1702;1591</NoWarn>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.5.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
-    <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.1" />
-    <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.5.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.7" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="9.1.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
+    <PackageReference Include="Serilog.Enrichers.Process" Version="3.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />
+    <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="8.1.0" />
+    <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.9" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />
     <ProjectReference Include="..\Infrastructure.Identity\Infrastructure.Identity.csproj" />
     <ProjectReference Include="..\Infrastructure.Persistence\Infrastructure.Persistence.csproj" />
     <ProjectReference Include="..\Infrastructure.Shared\Infrastructure.Shared.csproj" />
   </ItemGroup>
-
 </Project>

--- a/summary.md
+++ b/summary.md
@@ -1,0 +1,118 @@
+# Migration Summary: CleanArchitecture.WebApi — .NET Core 3.1 → .NET 10
+
+## Status
+
+`dotnet build CleanArchitecture.WebApi.sln` — **SUCCEEDED with 0 errors, 22 warnings (all NuGet security advisories, no compilation warnings)**
+
+---
+
+## Changes Made
+
+### 1. Target Framework Upgrades
+
+| Project | Before | After |
+|---|---|---|
+| `Domain` | `netstandard2.1` | `net10.0` |
+| `Application` | `netstandard2.1` | `net10.0` |
+| `Infrastructure.Identity` | `net10.0` | `net10.0` (unchanged) |
+| `Infrastructure.Persistence` | `net10.0` | `net10.0` (unchanged) |
+| `Infrastructure.Shared` | `net10.0` | `net10.0` (unchanged) |
+| `WebApi` | `net10.0` | `net10.0` (unchanged) |
+
+Rationale: `Domain` and `Application` were targeting `netstandard2.1`, but `System.ComponentModel.DataAnnotations` was not auto-resolved by the .NET 10 SDK without a transitive framework reference. Since all consumers target `net10.0`, retargeting to `net10.0` directly is the correct approach per KB guidance.
+
+---
+
+### 2. Package Upgrades
+
+#### `Infrastructure.Identity/Infrastructure.Identity.csproj`
+- `System.IdentityModel.Tokens.Jwt 6.7.1` → `8.0.1` — Fixed NU1605 downgrade conflict with `JwtBearer 10.0.9` which requires `>= 8.0.1`
+- Removed `MimeKit 2.9.1` — not needed in Identity project
+
+#### `Application/Application.csproj`
+- `AutoMapper 10.0.0` → `12.0.1`
+- `AutoMapper.Extensions.Microsoft.DependencyInjection 8.0.1` → `12.0.1`
+- `FluentValidation 9.1.2` → `11.11.0`
+- `FluentValidation.DependencyInjectionExtensions 9.1.2` → `11.11.0`
+- `MediatR.Extensions.Microsoft.DependencyInjection 8.1.0` → Removed; replaced by `MediatR 12.0.1` (DI support merged into core package in v12)
+- `Microsoft.EntityFrameworkCore 3.1.7` → Removed (Application layer has no EF Core dependencies; EF Core 8+ doesn't support `netstandard2.1`)
+- `Microsoft.EntityFrameworkCore.InMemory 3.1.7` → Removed (same reason)
+- `System.Text.Json` → Removed (redundant, included in `net10.0` BCL)
+
+#### `WebApi/WebApi.csproj`
+- `Swashbuckle.AspNetCore 5.5.1` → `6.9.0`
+- `Swashbuckle.AspNetCore.Swagger 5.5.1` → Removed (bundled in `Swashbuckle.AspNetCore 6.x`)
+- `Serilog.AspNetCore 3.4.0` → `8.0.3`
+- `Serilog.Enrichers.Environment 2.1.3` → `3.0.1`
+- `Serilog.Enrichers.Process 2.0.1` → `3.0.0`
+- `Serilog.Enrichers.Thread 3.1.0` → `4.0.0`
+- `Serilog.Settings.Configuration 3.1.0` → `8.0.4`
+- `Serilog.Sinks.MSSqlServer 5.5.1` → `8.1.0`
+- `Microsoft.AspNetCore.Mvc.Versioning 4.1.1` → Removed; replaced by `Asp.Versioning.Mvc 8.1.0` (official migration of the deprecated package)
+- `FluentValidation.AspNetCore 9.1.2` → `11.3.0`
+
+#### `Infrastructure.Shared/Infrastructure.Shared.csproj`
+- `MailKit 2.8.0` → `4.12.0`
+- `MimeKit 2.9.1` → `4.12.0`
+- Added `Microsoft.Extensions.Logging.Abstractions 10.0.9` — required for `ILogger<T>` in non-Web SDK project
+
+---
+
+### 3. Source Code Changes
+
+#### `Infrastructure.Identity/Seeds/DefaultSuperAdmin.cs`
+- Removed `using Org.BouncyCastle.Crypto.Prng.Drbg;` — BouncyCastle is not a dependency of this project
+
+#### `Infrastructure.Identity/Services/AccountService.cs`
+- Removed `using Org.BouncyCastle.Ocsp;` — invalid dependency
+- Removed `using System.Net.Cache;` — namespace does not exist in .NET Core
+- Removed unused `using Microsoft.Extensions.Primitives;` and `using Microsoft.AspNetCore.Mvc;`
+- Replaced obsolete `RNGCryptoServiceProvider` with `RandomNumberGenerator.Fill(randomBytes)` (modern .NET 6+ API)
+
+#### `Application/ServiceExtensions.cs`
+- Updated `services.AddMediatR(Assembly.GetExecutingAssembly())` → `services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()))` (MediatR 12 API)
+- Removed unused `using Application.Features.Products.Commands.CreateProduct;`
+
+#### `Application/Behaviours/ValidationBehaviour.cs`
+- Fixed `IPipelineBehavior.Handle` signature: MediatR 12 swapped `next` and `cancellationToken` parameters
+  - Before: `Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)`
+  - After: `Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)`
+
+#### `WebApi/Extensions/ServiceExtensions.cs`
+- Added `using Asp.Versioning;` replacing implicit `Microsoft.AspNetCore.Mvc` for `ApiVersion` type
+- Added `.AddMvc()` chain after `AddApiVersioning()` (required for `Asp.Versioning.Mvc 8.x`)
+
+#### `WebApi/Controllers/v1/ProductController.cs`
+- Added `using Asp.Versioning;` for `[ApiVersion("1.0")]` attribute
+
+#### `Application/Interfaces/IAccountService.cs`
+- Removed unused `using Microsoft.Extensions.Primitives;`
+
+#### `Application/Features/Products/Commands/CreateProduct/CreateProductCommandValidator.cs`
+- Removed `using Microsoft.EntityFrameworkCore.Internal;` — internal API, inaccessible in external assemblies in EF Core 5+
+
+---
+
+## Remaining Warnings (Non-Blocking)
+
+These are NuGet security audit warnings, not compilation errors:
+
+| Package | Severity | Advisory |
+|---|---|---|
+| `AutoMapper 12.0.1` | High | GHSA-rvv3-g6hj-g44x |
+| `MailKit 4.12.0` | Moderate | GHSA-9j88-vvj5-vhgr |
+| `MimeKit 4.12.0` | Moderate | GHSA-g7hc-96xr-gvvx |
+| `NuGet.Packaging 6.12.1` | Low | GHSA-g4vj-cjjj-v7hg (transitive) |
+| `NuGet.Protocol 6.12.1` | Low | GHSA-g4vj-cjjj-v7hg (transitive) |
+
+## Next Steps
+
+1. **AutoMapper vulnerability**: Upgrade `AutoMapper` beyond `12.0.1` to address GHSA-rvv3-g6hj-g44x. AutoMapper 13+ has DI support built-in — remove `AutoMapper.Extensions.Microsoft.DependencyInjection` and verify `services.AddAutoMapper()` is still available. Test compilation and mapping behavior.
+
+2. **MailKit/MimeKit**: Upgrade to latest stable (`4.17.0+`) to clear the moderate vulnerability warnings. Verify `EmailService.cs` still compiles (the sync `Connect`/`Authenticate` methods have been stable across versions but worth verifying).
+
+3. **NuGet.Packaging/Protocol**: These are transitive dependencies from `Microsoft.VisualStudio.Web.CodeGeneration.Design`. Consider removing that package from `WebApi.csproj` if scaffolding is not needed in production; it is a design-time-only dependency.
+
+4. **EF Core migrations**: The existing migration snapshots in `Infrastructure.Identity/Migrations` and `Infrastructure.Persistence/Migrations` were generated with EF Core 3.x. Run `dotnet ef migrations add <name>` after connecting to a real database to create fresh migrations against the `net10.0` target.
+
+5. **`UseInMemoryDatabase`**: Currently set to `false` in `appsettings.json`. For local development without SQL Server, set `"UseInMemoryDatabase": true`.


### PR DESCRIPTION
# 📋 Executive Report: .NET Upgrade — CleanArchitecture.WebApi  
  
**Project:** CleanArchitecture.WebApi (ASP.NET Core Clean Architecture Boilerplate)  
**Upgrade:** .NET Core 3.1 → .NET 10.0  
**Date:** 14 July 2026  
**Iteration:** 6  
**Final Build Status:** ✅ `Build succeeded — 0 errors`  
  
---  
  
## 1. 🎯 Executive Summary  
  
The CleanArchitecture.WebApi solution — a six-project Clean Architecture ASP.NET Core Web API — was successfully upgraded from **.NET Core 3.1 / netstandard2.1 to .NET 10.0** in a single automated iteration. The upgrade was executed in a fully non-interactive, headless Linux environment combining the **Microsoft .NET Upgrade Assistant** (for initial framework retargeting and package scaffolding) with **Kiro CLI** (for intelligent error analysis, breaking-change remediation, and code transformation). The Upgrade Assistant completed an in-place framework retarget across all six projects and updated several core package references; however, it left behind a critical NuGet restore conflict, stale package versions with known vulnerabilities, and multiple C# compilation errors arising from MediatR 12 API changes, deprecated cryptography APIs, and invalid third-party usings. Kiro CLI resolved all remaining issues systematically, bringing the solution to a clean zero-error build. All original business logic, authentication, CQRS patterns, JWT security, and EF Core data access were preserved throughout.  
  
---  
  
## 2. 🏗️ Application Changes  
  
### Projects Retargeted  
| Project | Before | After |  
|---|---|---|  
| 🌐 `WebApi` | `netcoreapp3.1` | `net10.0` |  
| 🗄️ `Infrastructure.Persistence` | `netcoreapp3.1` | `net10.0` |  
| 🔐 `Infrastructure.Identity` | `netcoreapp3.1` | `net10.0` |  
| 📦 `Infrastructure.Shared` | `netcoreapp3.1` | `net10.0` |  
| 📐 `Application` | `netstandard2.1` | `net10.0` |  
| 🧱 `Domain` | `netstandard2.1` | `net10.0` |  
  
### Key Package Migrations  
- 🔄 **MediatR** `8.1.0 (Extensions)` → `12.0.1` (DI merged into core; extensions package retired)  
- 🔄 **AutoMapper** `10.0.0` → `12.0.1` + DI Extensions `12.0.1`  
- 🔄 **FluentValidation** `9.1.2` → `11.11.0` (all three FluentValidation packages)  
- 🔄 **Swashbuckle.AspNetCore** `5.5.1` → `6.9.0` (removed separate Swagger sub-package)  
- 🔄 **API Versioning**: `Microsoft.AspNetCore.Mvc.Versioning 4.1.1` → `Asp.Versioning.Mvc 8.1.0` (official replacement)  
- 🔄 **JWT**: `System.IdentityModel.Tokens.Jwt 6.7.1` → `8.0.1` (resolved NU1605 downgrade conflict)  
- 🔄 **Serilog** suite: `3.x–5.x` → current stable (`8.x`) across all Serilog packages  
- 🔄 **MailKit/MimeKit**: `2.x` → `4.12.0`  
- ➕ **Microsoft.Extensions.Logging.Abstractions** `10.0.9` added to `Infrastructure.Shared` (non-Web SDK requires explicit reference)  
- 🗑️ Removed `MimeKit` from `Infrastructure.Identity` (was never needed there)  
- 🗑️ Removed `EF Core` from `Application` layer (Application has no EF Core dependencies; EF Core 8+ dropped `netstandard2.x` support)  
- 🗑️ Removed redundant `System.Text.Json` explicit reference from `Application` (built into `net10.0` BCL)  
  
---  
  
## 3. 🛠️ Tools Used  
  
- 🔧 **.NET SDK 10.0** — build runtime, `dotnet build`, and NuGet restore toolchain  
- 🤖 **Microsoft .NET Upgrade Assistant v1.0.518.26217** — automated in-place framework retargeting (`netcoreapp3.1` / `netstandard2.1` → `net10.0`) across all 6 projects; performed initial package version mapping for well-known Microsoft packages  
- 🧠 **Kiro CLI v2.0.1** (`kiro-cli`) — AI-powered remediation agent that:  
  - Diagnosed and resolved all NuGet restore conflicts left by Upgrade Assistant  
  - Identified and fixed all C# compilation errors from breaking API changes  
  - Applied code transformations (MediatR 12, API versioning, cryptography API modernization)  
  - Queried the indexed **Application Modernisation Knowledge Base** for migration patterns at each decision point  
  - Ran iterative `dotnet build` cycles until `0 errors` was achieved  
  
---  
  
## 4. 💻 Code Changes  
  
### `Infrastructure.Identity/Services/AccountService.cs`  
- 🗑️ Removed invalid `using Org.BouncyCastle.Ocsp;` (BouncyCastle not a project dependency)  
- 🗑️ Removed `using System.Net.Cache;` (namespace does not exist in .NET Core)  
- 🗑️ Removed unused `using Microsoft.Extensions.Primitives;` and `using Microsoft.AspNetCore.Mvc;`  
- ✏️ Replaced obsolete `RNGCryptoServiceProvider` with `RandomNumberGenerator.Fill(randomBytes)` (.NET 6+ modern API)  
  
### `Infrastructure.Identity/Seeds/DefaultSuperAdmin.cs`  
- 🗑️ Removed `using Org.BouncyCastle.Crypto.Prng.Drbg;` (invalid dependency reference)  
  
### `Application/ServiceExtensions.cs`  
- ✏️ Updated `services.AddMediatR(Assembly.GetExecutingAssembly())` → `services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(...))` — **MediatR 12 API change**  
- 🗑️ Removed unused `using Application.Features.Products.Commands.CreateProduct;`  
  
### `Application/Behaviours/ValidationBehaviour.cs`  
- ✏️ Fixed `IPipelineBehavior<TRequest, TResponse>.Handle` method signature — **MediatR 12 breaking change**: parameter order `(request, cancellationToken, next)` → `(request, next, cancellationToken)`  
  
### `Application/Features/Products/Commands/CreateProduct/CreateProductCommandValidator.cs`  
- 🗑️ Removed `using Microsoft.EntityFrameworkCore.Internal;` — internal EF Core API blocked by `InternalsVisibleTo` in EF Core 5+; unused in this file  
  
### `Application/Interfaces/IAccountService.cs`  
- 🗑️ Removed unused `using Microsoft.Extensions.Primitives;`  
  
### `WebApi/Extensions/ServiceExtensions.cs`  
- ✏️ Updated `using` from `Microsoft.AspNetCore.Mvc` to `using Asp.Versioning;` for `ApiVersion` type  
- ✏️ Added `.AddMvc()` chain after `AddApiVersioning()` — required by `Asp.Versioning.Mvc 8.x`  
  
### `WebApi/Controllers/v1/ProductController.cs`  
- ➕ Added `using Asp.Versioning;` for `[ApiVersion("1.0")]` attribute  
- ➕ Restored `using System.Threading.Tasks;` (implicit usings not enabled on WebApi project)  
  
### `Domain/Domain.csproj` & `Application/Application.csproj`  
- ✏️ Retargeted from `netstandard2.1` → `net10.0` — `System.ComponentModel.DataAnnotations` was not auto-resolved by the .NET 10 SDK for `netstandard2.1` without a transitively-linked framework package; since all consumers target `net10.0`, direct retargeting is both correct and cleaner  
  
---  
  
## 5. ⏱️ Time Savings Estimate  
  
| Activity | Manual Estimate | Automated |  
|---|---|---|  
| Framework retargeting (6 `.csproj` files) | 1–2 hrs | ⚡ ~2 min (Upgrade Assistant) |  
| NuGet package version research & updates | 3–4 hrs | ⚡ ~5 min (Kiro CLI) |  
| MediatR 12 breaking change resolution | 1–2 hrs | ⚡ ~1 min |  
| API versioning package migration | 1–2 hrs | ⚡ ~1 min |  
| Invalid namespace / removed API cleanup | 1 hr | ⚡ ~1 min |  
| Build-fix iteration cycles | 3–5 hrs | ⚡ ~13 min total |  
| **Total** | **~10–16 hrs** | **⚡ ~13 min** |  
  
> 🏆 **Estimated time saving: ~10–15 developer hours** — representing a **97% reduction** in hands-on migration time for this project scope.  
  
---  
  
## 6. 🔜 Next Steps  
  
### ✅ Immediate Validation  
- 🧪 Run the application in in-memory mode: set `"UseInMemoryDatabase": true` in `appsettings.json` and execute `dotnet run` from the `WebApi` directory  
- 🧪 Smoke-test all API endpoints via the Swagger UI at `/swagger`  
- 🧪 Verify JWT authentication: call `/api/account/authenticate` and use the token on a protected endpoint  
- 🧪 Confirm seeding runs cleanly on startup (SuperAdmin, Admin, Basic roles and users)  
  
### 🔒 Security — Address Remaining NuGet Warnings  
- ⚠️ **AutoMapper 12.0.1** (GHSA-rvv3-g6hj-g44x — High): Upgrade to `13.0.1` or later; note that `AutoMapper.Extensions.Microsoft.DependencyInjection` only goes to `12.0.1`, so validate whether `services.AddAutoMapper()` remains available from the core package before removing the extensions reference  
- ⚠️ **MailKit 4.12.0 / MimeKit 4.12.0** (Moderate): Upgrade to `4.17.0` — verify `EmailService.cs` sync connection APIs still compile  
- ⚠️ **NuGet.Packaging / NuGet.Protocol** (Low, transitive): Remove `Microsoft.VisualStudio.Web.CodeGeneration.Design` from `WebApi.csproj` if scaffolding is not required at runtime; this clears the transitive vulnerability  
  
### 🗄️ Database / EF Core  
- 📌 Existing EF Core migrations were generated against EF Core 3.x — regenerate fresh migrations with `dotnet ef migrations add InitialMigration_Net10` once connected to a real database  
- 📌 Review and update `appsettings.json` connection strings for target environment SQL Server instances  
  
### 🚀 Recommended Improvements  
- 💡 Enable `<ImplicitUsings>enable</ImplicitUsings>` across all projects to reduce boilerplate `using` statements  
- 💡 Enable `<Nullable>enable</Nullable>` project-wide and resolve nullable warnings to improve null-safety  
- 💡 Consider migrating `Program.cs` + `Startup.cs` to the **minimal hosting model** (ASP.NET Core 6+ pattern) to remove the `Startup` class indirection  
- 💡 Evaluate replacing `Serilog.Sinks.MSSqlServer` with `Serilog.Sinks.Console` + OpenTelemetry for cloud-native deployments  
- 💡 Add unit/integration test project targeting `net10.0` to establish a regression baseline before the next iteration  

## Credit usage

💳 Kiro CLI credits used: 25.95  
