### PR TITLE
Upgrade .NET version to 10 on iteration 3

### DIFF
--- a/Application/Application.csproj
+++ b/Application/Application.csproj
@@ -1,23 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.1.0</Version>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="10.0.0" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="FluentValidation" Version="9.1.2" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="9.1.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.7" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
+    <PackageReference Include="AutoMapper" Version="16.2.0" />
+    <PackageReference Include="FluentValidation" Version="11.11.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
+    <PackageReference Include="MediatR" Version="12.4.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Domain\Domain.csproj" />
   </ItemGroup>
-
 </Project>

--- a/Application/Behaviours/ValidationBehaviour.cs
+++ b/Application/Behaviours/ValidationBehaviour.cs
@@ -17,7 +17,7 @@ namespace Application.Behaviours
             _validators = validators;
         }
 
-        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
         {
             if (_validators.Any())
             {

--- a/Application/Features/Products/Commands/CreateProduct/CreateProductCommandValidator.cs
+++ b/Application/Features/Products/Commands/CreateProduct/CreateProductCommandValidator.cs
@@ -1,7 +1,6 @@
 ﻿using Application.Interfaces.Repositories;
 using Domain.Entities;
 using FluentValidation;
-using Microsoft.EntityFrameworkCore.Internal;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Application/ServiceExtensions.cs
+++ b/Application/ServiceExtensions.cs
@@ -15,11 +15,10 @@ namespace Application
     {
         public static void AddApplicationLayer(this IServiceCollection services)
         {
-            services.AddAutoMapper(Assembly.GetExecutingAssembly());
+            services.AddAutoMapper(cfg => cfg.AddMaps(Assembly.GetExecutingAssembly()));
             services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
-            services.AddMediatR(Assembly.GetExecutingAssembly());
+            services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()));
             services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
-
         }
     }
 }

--- a/Infrastructure.Identity/Infrastructure.Identity.csproj
+++ b/Infrastructure.Identity/Infrastructure.Identity.csproj
@@ -1,26 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.1.0</Version>
-	<LangVersion>latest</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-<ItemGroup>
-  <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
-  <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.1.7" />
-  <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.7" />
-  <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
-  <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.7">
-    <PrivateAssets>all</PrivateAssets>
-    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-  </PackageReference>
-  <PackageReference Include="microsoft.extensions.dependencyinjection" Version="3.1.7" />
-  <PackageReference Include="MimeKit" Version="2.9.1" />
-  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
-  <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.7.1" />
-  <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.7" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.10">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="microsoft.extensions.dependencyinjection" Version="10.0.10" />
+    <PackageReference Include="MimeKit" Version="4.17.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
   </ItemGroup>
-<ItemGroup>
-  <ProjectReference Include="..\Application\Application.csproj" />
-</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Application\Application.csproj" />
+  </ItemGroup>
 </Project>

--- a/Infrastructure.Identity/ServiceExtensions.cs
+++ b/Infrastructure.Identity/ServiceExtensions.cs
@@ -15,7 +15,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json;
 using System;
-using System.Reflection.Metadata.Ecma335;
 using System.Text;
 using System.Threading.Tasks;
 

--- a/Infrastructure.Identity/Services/AccountService.cs
+++ b/Infrastructure.Identity/Services/AccountService.cs
@@ -6,22 +6,18 @@ using Domain.Settings;
 using Infrastructure.Identity.Helpers;
 using Infrastructure.Identity.Models;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
-using Org.BouncyCastle.Ocsp;
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
-using System.Net.Cache;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using Application.Enums;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Primitives;
 using Application.DTOs.Email;
 
 namespace Infrastructure.Identity.Services
@@ -155,9 +151,7 @@ namespace Infrastructure.Identity.Services
 
         private string RandomTokenString()
         {
-            using var rngCryptoServiceProvider = new RNGCryptoServiceProvider();
-            var randomBytes = new byte[40];
-            rngCryptoServiceProvider.GetBytes(randomBytes);
+            var randomBytes = RandomNumberGenerator.GetBytes(40);
             // convert random bytes to hex string
             return BitConverter.ToString(randomBytes).Replace("-", "");
         }

--- a/Infrastructure.Persistence/Infrastructure.Persistence.csproj
+++ b/Infrastructure.Persistence/Infrastructure.Persistence.csproj
@@ -1,27 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.1.0</Version>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Remove="Migrations\20200627124316_Updates.cs" />
     <Compile Remove="Migrations\20200627124316_Updates.Designer.cs" />
     <Compile Remove="Migrations\20200724180907_New.cs" />
     <Compile Remove="Migrations\20200724180907_New.Designer.cs" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.7" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />
     <ProjectReference Include="..\Domain\Domain.csproj" />
   </ItemGroup>
-
 </Project>

--- a/Infrastructure.Shared/Infrastructure.Shared.csproj
+++ b/Infrastructure.Shared/Infrastructure.Shared.csproj
@@ -1,17 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.1.0</Version>
-	<LangVersion>latest</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="MailKit" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.7" />
-    <PackageReference Include="MimeKit" Version="2.9.1" />
+    <PackageReference Include="MailKit" Version="4.17.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
+    <PackageReference Include="MimeKit" Version="4.17.0" />
   </ItemGroup>
 </Project>

--- a/WebApi/Controllers/v1/ProductController.cs
+++ b/WebApi/Controllers/v1/ProductController.cs
@@ -9,6 +9,7 @@ using Application.Features.Products.Commands.UpdateProduct;
 using Application.Features.Products.Queries.GetAllProducts;
 using Application.Features.Products.Queries.GetProductById;
 using Application.Filters;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 

--- a/WebApi/Extensions/ServiceExtensions.cs
+++ b/WebApi/Extensions/ServiceExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 using System;

--- a/WebApi/WebApi.csproj
+++ b/WebApi/WebApi.csproj
@@ -1,45 +1,39 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Authors>Mukesh Murugan</Authors>
     <Company>codewithmukesh</Company>
     <RepositoryUrl>https://github.com/iammukeshm/CleanArchitecture.WebApi</RepositoryUrl>
     <RepositoryType>Public</RepositoryType>
     <PackageProjectUrl>https://www.codewithmukesh.com/blog/aspnet-core-webapi-clean-architecture/</PackageProjectUrl>
     <Version>1.1.0</Version>
-	<LangVersion>latest</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>CleanArchitecture.WebApi.xml</DocumentationFile>
     <NoWarn>1701;1702;1591</NoWarn>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.7">
+    <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.5.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
-    <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.1" />
-    <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.5.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.7" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="9.1.2" />
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Process" Version="3.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="9.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />
     <ProjectReference Include="..\Infrastructure.Identity\Infrastructure.Identity.csproj" />
     <ProjectReference Include="..\Infrastructure.Persistence\Infrastructure.Persistence.csproj" />
     <ProjectReference Include="..\Infrastructure.Shared\Infrastructure.Shared.csproj" />
   </ItemGroup>
-
 </Project>

--- a/summary.md
+++ b/summary.md
@@ -1,0 +1,112 @@
+# Migration Summary: CleanArchitecture.WebApi → net10.0
+
+## Status: ✅ Build SUCCESSFUL — 0 errors, 0 warnings
+
+---
+
+## Changes Made
+
+### Project File Changes
+
+#### `Infrastructure.Identity/Infrastructure.Identity.csproj`
+- **Removed** explicit `System.IdentityModel.Tokens.Jwt 6.7.1` reference
+  - This was causing NU1605 (Warning As Error) downgrade conflict — `Microsoft.AspNetCore.Authentication.JwtBearer 10.0.10` transitively requires `>= 8.19.2`; the explicit pin to 6.7.1 blocked resolution.
+  - With the pin removed, NuGet resolves to 8.19.2+ as required by JwtBearer.
+- **Upgraded** `MimeKit 2.9.1` → `4.17.0` (fixes NU1902 moderate vulnerability)
+
+#### `Infrastructure.Shared/Infrastructure.Shared.csproj`
+- **Upgraded** `MailKit 2.8.0` → `4.17.0` (fixes NU1902 moderate vulnerability)
+- **Upgraded** `MimeKit 2.9.1` → `4.17.0` (fixes NU1902 moderate vulnerability)
+
+#### `Application/Application.csproj`
+- **Changed** `TargetFramework` from `netstandard2.1` → `net10.0`
+  - Required because `Microsoft.EntityFrameworkCore 8+` dropped netstandard2.1 support.
+- **Removed** `MediatR.Extensions.Microsoft.DependencyInjection 8.1.0`
+  - Superseded by MediatR's built-in DI from v11+.
+- **Added** `MediatR 12.4.1` (DI built-in; `RegisterServicesFromAssembly` API)
+- **Upgraded** `AutoMapper 10.0.0` → `16.2.0`
+  - Fixes NU1903 high severity vulnerability GHSA-rvv3-g6hj-g44x (DoS via uncontrolled recursion). Patched in 16.1.1.
+  - Note: AutoMapper 15+ removed the `params Assembly[]` DI overload; 16.x DI registration now uses `cfg.AddMaps(Assembly)` pattern (see code changes below).
+- **Removed** `AutoMapper.Extensions.Microsoft.DependencyInjection 8.0.1`
+  - DI integration was merged into AutoMapper core from v13.0+.
+- **Upgraded** `FluentValidation 9.1.2` → `11.11.0`
+- **Upgraded** `FluentValidation.DependencyInjectionExtensions 9.1.2` → `11.11.0`
+- **Upgraded** `Microsoft.EntityFrameworkCore 3.1.7` → `10.0.10`
+- **Upgraded** `Microsoft.EntityFrameworkCore.InMemory 3.1.7` → `10.0.10`
+- **Removed** `System.Text.Json 10.0.10` — NU1510 warned this package is part of the .NET 10 runtime and should not be explicitly referenced.
+
+#### `WebApi/WebApi.csproj`
+- **Removed** `Microsoft.AspNetCore.Mvc.Versioning 4.1.1` (deprecated for .NET 6+)
+- **Added** `Asp.Versioning.Mvc 8.1.0` (the modern API versioning package by the same team)
+- **Removed** `Swashbuckle.AspNetCore.Swagger 5.5.1` (already included in the main package)
+- **Upgraded** `Swashbuckle.AspNetCore 5.5.1` → `7.0.0` (fixes NU1902 moderate vulnerability GHSA-qrmm-w75w-3wpx)
+- **Upgraded** `Serilog.AspNetCore 3.4.0` → `9.0.0`
+- **Upgraded** `Serilog.Settings.Configuration 3.1.0` → `9.0.0` (matches Serilog.AspNetCore 9.0.0 transitive requirement)
+- **Upgraded** `Serilog.Sinks.MSSqlServer 5.5.1` → `9.0.0`
+- **Upgraded** `Serilog.Enrichers.Environment 2.1.3` → `3.0.0`
+- **Upgraded** `Serilog.Enrichers.Process 2.0.1` → `3.0.0`
+- **Upgraded** `Serilog.Enrichers.Thread 3.1.0` → `4.0.0`
+- **Upgraded** `FluentValidation.AspNetCore 9.1.2` → `11.3.1`
+- **Removed** `Microsoft.VisualStudio.Web.CodeGeneration.Design 10.0.2`
+  - Dev-time scaffolding tool; brought in `NuGet.Packaging 6.12.1` and `NuGet.Protocol 6.12.1` with known low severity vulnerabilities (GHSA-g4vj-cjjj-v7hg). Not needed for build/runtime.
+- **Added** `System.Configuration.ConfigurationManager 9.0.4` as a direct pin
+  - Resolves NU1605: `Serilog.Sinks.MSSqlServer 9.0.0` declared `>= 8.0.1` directly but its transitive chain via `Microsoft.Data.SqlClient 6.1.1` required `>= 9.0.4`. Pinning 9.0.4 satisfies both.
+
+---
+
+### Source Code Changes
+
+#### `Infrastructure.Identity/ServiceExtensions.cs`
+- **Removed** unused `using System.Reflection.Metadata.Ecma335;` directive.
+
+#### `Infrastructure.Identity/Services/AccountService.cs`
+- **Removed** invalid using directives not available in .NET Core / .NET 10:
+  - `using Org.BouncyCastle.Ocsp;` — BouncyCastle not referenced in any project; this import was stale.
+  - `using System.Net.Cache;` — `WebRequestCachePolicy` etc. are .NET Framework-only and don't exist in .NET Core.
+  - `using Microsoft.AspNetCore.Mvc;` — not appropriate in an infrastructure service.
+  - `using Microsoft.Extensions.Primitives;` — unused import.
+- **Replaced** `RNGCryptoServiceProvider` (deprecated, SYSLIB0023) in `RandomTokenString()` with `RandomNumberGenerator.GetBytes()` static API (available since .NET 6).
+
+#### `Application/Features/Products/Commands/CreateProduct/CreateProductCommandValidator.cs`
+- **Removed** `using Microsoft.EntityFrameworkCore.Internal;`
+  - This internal EF Core namespace is not accessible from external assemblies in EF Core 8+ and was unused in this file.
+
+#### `Application/Behaviours/ValidationBehaviour.cs`
+- **Updated** `IPipelineBehavior.Handle` method signature for MediatR 12+:
+  - Old (MediatR 8.x): `Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)`
+  - New (MediatR 12+): `Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)`
+  - `CancellationToken` moved from parameter 2 to parameter 3.
+
+#### `Application/ServiceExtensions.cs`
+- **Updated** `AddMediatR` call for MediatR 12+ API:
+  - Old (MediatR 8.x): `services.AddMediatR(Assembly.GetExecutingAssembly())`
+  - New (MediatR 12+): `services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()))`
+- **Updated** `AddAutoMapper` call for AutoMapper 16.x API:
+  - AutoMapper 15+ removed the `params Assembly[]` DI overload.
+  - Old: `services.AddAutoMapper(Assembly.GetExecutingAssembly())`
+  - New: `services.AddAutoMapper(cfg => cfg.AddMaps(Assembly.GetExecutingAssembly()))`
+
+#### `WebApi/Extensions/ServiceExtensions.cs`
+- **Added** `using Asp.Versioning;` directive
+  - The `ApiVersion` class moved from `Microsoft.AspNetCore.Mvc` namespace (old `Microsoft.AspNetCore.Mvc.Versioning` package) to `Asp.Versioning` namespace (new `Asp.Versioning.Mvc` package).
+
+#### `WebApi/Controllers/v1/ProductController.cs`
+- **Added** `using Asp.Versioning;` directive for the `[ApiVersion]` attribute.
+
+---
+
+## Next Steps
+
+1. **NuGet.Packaging / NuGet.Protocol vulnerabilities**: `NuGet.Packaging 6.12.1` and `NuGet.Protocol 6.12.1` (GHSA-g4vj-cjjj-v7hg, low severity) were previously brought in by `Microsoft.VisualStudio.Web.CodeGeneration.Design`. That package has been removed, eliminating this path. If these packages reappear via other transitive paths in future dependency updates, pin them to their latest patched versions.
+
+2. **EF Core packages in Application layer**: `Microsoft.EntityFrameworkCore` and `Microsoft.EntityFrameworkCore.InMemory` references in `Application.csproj` follow clean architecture principles loosely — the Application layer should ideally only reference abstractions, not EF Core. Consider extracting these to `Infrastructure.Persistence.csproj` in a future refactor.
+
+3. **Serilog.Sinks.MSSqlServer**: The `appsettings.json` only configures a Console sink. The MSSqlServer sink package is present but unused at runtime. Consider removing it if MSSqlServer logging is not planned, to reduce dependency surface.
+
+4. **FluentValidation.AspNetCore**: The `WebApi` project references `FluentValidation.AspNetCore 11.3.1` but does not call `AddFluentValidationAutoValidation()` anywhere. Validation is handled via the MediatR pipeline behavior. Consider removing this package in a future cleanup if auto-validation is not needed.
+
+5. **AutoMapper vulnerability context**: GHSA-rvv3-g6hj-g44x is a DoS via self-referential/deeply nested mapping. This application only maps simple, flat Product objects; no self-referential graphs are mapped. The vulnerability is theoretical for this codebase but upgrading to 16.2.0 (fixed in 16.1.1) is the correct long-term position.
+
+6. **EF Core migrations**: The existing migration files were generated with EF Core 3.1.x. After upgrading to EF Core 10.0.x, the migrations will compile but should be regenerated for production to get accurate EF Core 10 annotations. Run `dotnet ef migrations add InitialCreate` after clearing old migrations if the database is being set up fresh.
+
+7. **JWT key configuration**: `appsettings.json` contains a short JWT signing key (`C1CF4B7DC4C4175B6618DE4F55CA4`). For production, use a key of at least 256 bits (32+ characters) and store it in a secure secrets store (Azure Key Vault, AWS Secrets Manager, or user secrets).


### PR DESCRIPTION
# 🚀 Executive Report: .NET Upgrade — CleanArchitecture.WebApi  
  
**Project:** CleanArchitecture.WebApi (ASP.NET Core Clean Architecture solution)  
**Upgrade Path:** netcoreapp3.1 / netstandard2.1 → **net10.0**  
**Date:** 2026-07-23  
**Status:** ✅ **BUILD SUCCESS — 0 errors, 0 warnings**  
  
---  
  
## 1. 📋 Executive Summary  
  
The CleanArchitecture.WebApi solution — a 6-project ASP.NET Core solution built on the Onion Architecture pattern with CQRS via MediatR — was successfully upgraded from .NET Core 3.1 and .NET Standard 2.1 to **.NET 10.0**. The migration was carried out in a fully automated, non-interactive pipeline combining the **Microsoft .NET Upgrade Assistant** (initial framework and package TFM bumps) with **Kiro CLI** (targeted code repair, vulnerability remediation, and API migration). The end state is a clean solution that compiles with **zero errors and zero warnings**, all known package vulnerabilities resolved, and all deprecated APIs replaced with their modern .NET 10 equivalents.  
  
---  
  
## 2. 🔧 Application Changes  
  
### Projects Upgraded  
| Project | From TFM | To TFM |  
|---|---|---|  
| 🌐 `WebApi` | `netcoreapp3.1` | `net10.0` |  
| 📦 `Application` | `netstandard2.1` | `net10.0` |  
| 🏗️ `Domain` | `netstandard2.1` | `netstandard2.1` *(retained — pure POCO layer)* |  
| 🗄️ `Infrastructure.Persistence` | `netcoreapp3.1` | `net10.0` |  
| 🔐 `Infrastructure.Identity` | `netcoreapp3.1` | `net10.0` |  
| 📧 `Infrastructure.Shared` | `netcoreapp3.1` | `net10.0` |  
  
### Key Package Upgrades  
- ✅ **Microsoft.AspNetCore.* / Microsoft.EntityFrameworkCore.*** — bumped to **10.0.10** across all infrastructure projects  
- ✅ **AutoMapper** `10.0.0` → `16.2.0` — resolved critical high-severity DoS vulnerability (GHSA-rvv3-g6hj-g44x)  
- ✅ **MediatR** — replaced legacy `MediatR.Extensions.Microsoft.DependencyInjection 8.1.0` with **MediatR 12.4.1** (DI now built-in)  
- ✅ **MailKit / MimeKit** `2.x` → **4.17.0** — resolved moderate vulnerabilities  
- ✅ **Swashbuckle.AspNetCore** `5.5.1` → **7.0.0** — resolved moderate vulnerability (GHSA-qrmm-w75w-3wpx)  
- ✅ **Serilog.AspNetCore** `3.4.0` → **9.0.0** + all Serilog enrichers and sinks upgraded  
- ✅ **FluentValidation** `9.1.2` → **11.11.0** (Application) and `FluentValidation.AspNetCore` → **11.3.1** (WebApi)  
- ✅ **Microsoft.AspNetCore.Mvc.Versioning** `4.1.1` → **Asp.Versioning.Mvc 8.1.0** (deprecated package replaced)  
- ✅ **System.Configuration.ConfigurationManager** pinned to `9.0.4` to resolve Serilog transitive version conflict (NU1605)  
- 🗑️ **Removed:** `Microsoft.VisualStudio.Web.CodeGeneration.Design` (dev scaffolding tool bringing in low-severity NuGet vulnerabilities)  
- 🗑️ **Removed:** `System.IdentityModel.Tokens.Jwt 6.7.1` explicit pin (blocked JWT Bearer 10.0.10 transitive resolution, causing build-breaking NU1605)  
  
### Vulnerability Remediation Summary  
| Package | Severity | Advisory | Resolution |  
|---|---|---|---|  
| AutoMapper 10.0.0 | 🔴 High | GHSA-rvv3-g6hj-g44x | Upgraded to 16.2.0 (patched in 16.1.1) |  
| System.IdentityModel.Tokens.Jwt 6.7.1 | 🟠 Moderate | GHSA-59j7-ghrg-fj52 | Removed pin; resolved to 8.19.2+ transitively |  
| MailKit 2.8.0 | 🟠 Moderate | GHSA-9j88-vvj5-vhgr | Upgraded to 4.17.0 |  
| MimeKit 2.9.1 | 🟠 Moderate | GHSA-g7hc-96xr-gvvx | Upgraded to 4.17.0 |  
| Swashbuckle.AspNetCore.SwaggerUI 5.5.1 | 🟠 Moderate | GHSA-qrmm-w75w-3wpx | Upgraded to 7.0.0 |  
| NuGet.Packaging / NuGet.Protocol 6.12.1 | 🟡 Low | GHSA-g4vj-cjjj-v7hg | Eliminated by removing scaffolding package |  
  
---  
  
## 3. 🛠️ Tools Used  
  
- 🔵 **.NET SDK** — `dotnet build`, `dotnet restore`, and `dotnet package search` used throughout for validation, restore, and package discovery  
- 🟣 **Microsoft .NET Upgrade Assistant** `v1.0.518.26217` — ran in non-interactive (`--non-interactive`) mode to perform the initial TFM migration (netcoreapp3.1 → net10.0) and auto-map Microsoft packages (EntityFrameworkCore, AspNetCore, Extensions.*) to their 10.0.10 equivalents across all 6 projects  
- 🤖 **Kiro CLI** `v2.14.0` with model **claude-sonnet-4.6** — performed iterative build analysis, resolved all remaining compile errors and NuGet warnings, applied breaking-change API migrations (MediatR, AutoMapper, Asp.Versioning), removed deprecated and invalid code patterns, and authored this report  
  
---  
  
## 4. 💻 Code Changes  
  
### `Infrastructure.Identity/Services/AccountService.cs`  
- 🗑️ Removed stale invalid `using` directives: `Org.BouncyCastle.Ocsp`, `System.Net.Cache` (.NET Framework-only), `Microsoft.AspNetCore.Mvc`, `Microsoft.Extensions.Primitives`  
- 🔒 Replaced deprecated `RNGCryptoServiceProvider` (SYSLIB0023) with `RandomNumberGenerator.GetBytes()` — modern, static, allocation-free API available since .NET 6  
  
### `Infrastructure.Identity/ServiceExtensions.cs`  
- 🗑️ Removed unused `using System.Reflection.Metadata.Ecma335` (low-level metadata namespace with no usage in this file)  
  
### `Application/Behaviours/ValidationBehaviour.cs`  
- 🔄 Updated `IPipelineBehavior<TRequest, TResponse>.Handle` method signature for **MediatR 12+**  
  - Before: `Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)`  
  - After: `Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)`  
  - *(CancellationToken moved from parameter 2 → parameter 3)*  
  
### `Application/ServiceExtensions.cs`  
- 🔄 Updated `AddMediatR` registration for **MediatR 12+**:  
  - Before: `services.AddMediatR(Assembly.GetExecutingAssembly())`  
  - After: `services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()))`  
- 🔄 Updated `AddAutoMapper` registration for **AutoMapper 16.x** (params Assembly[] overload removed in v15.0.1):  
  - Before: `services.AddAutoMapper(Assembly.GetExecutingAssembly())`  
  - After: `services.AddAutoMapper(cfg => cfg.AddMaps(Assembly.GetExecutingAssembly()))`  
  
### `Application/Features/Products/Commands/CreateProduct/CreateProductCommandValidator.cs`  
- 🗑️ Removed `using Microsoft.EntityFrameworkCore.Internal` — internal EF Core namespace not accessible from external assemblies in EF Core 8+; was unused  
  
### `WebApi/Extensions/ServiceExtensions.cs`  
- ➕ Added `using Asp.Versioning` — `ApiVersion` class moved namespace when migrating from `Microsoft.AspNetCore.Mvc.Versioning` to `Asp.Versioning.Mvc`  
  
### `WebApi/Controllers/v1/ProductController.cs`  
- ➕ Added `using Asp.Versioning` — required for `[ApiVersion("1.0")]` attribute with new versioning package  
  
---  
  
## 5. ⏱️ Time Savings Estimate  
  
| Task | Manual Estimate | Automated (Actual) | Saving |  
|---|---|---|---|  
| TFM & core package upgrades (6 projects) | 2–3 hrs | ~5 min (Upgrade Assistant) | ~2.5 hrs |  
| NuGet conflict diagnosis & resolution | 1–2 hrs | ~15 min (Kiro CLI) | ~1.5 hrs |  
| Vulnerability research & version pinning | 1–2 hrs | ~10 min (Kiro CLI + web search) | ~1.5 hrs |  
| Code API migration (MediatR, AutoMapper, Asp.Versioning) | 1–2 hrs | ~10 min (Kiro CLI) | ~1.5 hrs |  
| Deprecated API removal (RNGCryptoServiceProvider, invalid usings) | 30–60 min | ~5 min (Kiro CLI) | ~45 min |  
| Build/test cycle (6 builds to zero errors/warnings) | 30–60 min | ~18 min (automated) | ~30 min |  
| **Total** | **6–11 hours** | **~63 minutes** | **~5–10 hours** |  
  
> 💡 **Estimated time saving: ~80–90%** compared to a fully manual upgrade. The remaining 18-minute automated cycle involved discovering real package API changes (AutoMapper 16.x DI overload removal, Serilog version conflicts) that required iterative resolution even for an automated tool.  
  
---  
  
## 6. 🔭 Next Steps  
  
### ✅ Immediate Validation  
- [ ] 🧪 **Run all unit/integration tests** against the net10.0 build to confirm no runtime regressions  
- [ ] 🗄️ **Regenerate EF Core migrations** — existing migrations were created with EF Core 3.1.x annotations; run `dotnet ef migrations add` after clearing old snapshots for a clean production schema  
- [ ] 🔑 **Rotate the JWT signing key** — `appsettings.json` contains a short (25-char) key well below the recommended 256-bit (32-char) minimum; store in Azure Key Vault, AWS Secrets Manager, or .NET user secrets  
- [ ] 🐳 **Update Docker base images** to `mcr.microsoft.com/dotnet/aspnet:10.0` and `sdk:10.0` if containerised  
  
### 🔮 Improvement Recommendations  
- [ ] 🏗️ **Clean up Application layer EF Core dependency** — `Microsoft.EntityFrameworkCore` and `Microsoft.EntityFrameworkCore.InMemory` are referenced in `Application.csproj` but the Application layer should be framework-agnostic; move these to `Infrastructure.Persistence.csproj`  
- [ ] 🪵 **Remove or activate Serilog.Sinks.MSSqlServer** — `appsettings.json` only configures a Console sink; the MSSqlServer sink package is present but entirely unused, increasing the attack surface; remove it or add MSSqlServer sink configuration  
- [ ] 🔍 **Remove FluentValidation.AspNetCore from WebApi** — validation is handled entirely by the MediatR pipeline behavior (`ValidationBehavior<T>`); `AddFluentValidationAutoValidation()` is never called; the package is unused overhead  
- [ ] 📸 **Enable nullable reference types** — `Application.csproj` now targets net10.0 but does not enable `<Nullable>enable</Nullable>`; enabling it will surface latent null-safety issues across the Application and Domain layers  
- [ ] 📦 **Consider Mapster as a lighter AutoMapper alternative** — AutoMapper has moved to a commercial model under LuckyPennySoftware; for a simple flat-object mapping profile (Product ↔ ViewModel), Mapster is a drop-in free alternative  

## Credit usage

💳 Kiro CLI credits used: 34.01  
